### PR TITLE
Documentation Update

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,3 +8,44 @@ ability to merge PRs and respond to issues.
 
 - [Issue Reporting and Lifecycle](contributing/issue-reporting-and-lifecycle.md)
 - [Pull Request Submission and Lifecycle](contributing/pullrequest-submission-and-lifecycle.md)
+
+
+## Getting Started on Development
+
+### How to Write Terraform Providers
+
+Check out the [Terraform Provider Tutorial](https://learn.hashicorp.com/tutorials/terraform/provider-setup)
+
+### Setting Up A Debugger
+
+How to set up a debugger is described [on Terraform's website](https://www.terraform.io/docs/extend/debugging.html#enabling-debugging-in-a-provider)
+
+#### GoLand
+
+**NOTE:** These instructions were written on Windows but port directly to Linux.
+
+1. In [main.go](../main.go) and fine the line:
+
+        flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+
+2. Change false to true and then recompile the provider with `go build -o terraform-provider-redfish.exe`
+3. Install Delve with 
+
+        git clone https://github.com/go-delve/delve
+        cd delve
+        go install github.com/go-delve/delve/cmd/dlv
+
+4. It will install to %GOPATH%. On Windows this defaults to `C:\Users\YOURNAME\go`.
+5. `cd` to the directory with your provider binary and run `%GOPATH%\dlv.exe exec --headless --listen=:51706 --accept-multiclient --api-version=2 .\terraform-provider-redfish.exe -- --debug`
+6. Configure GoLand for remote debugging by following [these instructions](https://golangforall.com/en/post/go-docker-delve-remote-debug.html#goland-ide). Use the port from step #5
+7. Run your GoLand debugging profile. If everything was configured correctly, you should see something like this on the command line:
+
+        C:\Users\grant\Documents\code\terraform-provider-redfish>dlv exec --headless --listen=:51706 --accept-multiclient --api-version=2 .\terraform-provider-redfish.exe -- --debug
+        API server listening at: [::]:51706
+        {"@level":"debug","@message":"plugin address","@timestamp":"2021-02-25T18:25:46.044480-05:00","address":"127.0.0.1:51865","network":"tcp"}
+        Provider server started; to attach Terraform, set TF_REATTACH_PROVIDERS to the following:
+        {"registry.terraform.io/dell/redfish":{"Protocol":"grpc","Pid":32044,"Test":true,"Addr":{"Network":"tcp","String":"127.0.0.1:51865"}}}
+
+
+8. This means the debugger is up and running. Set your breakpoints as you please and then open a separate terminal window for debugging. In that terminal window you need to create an environment variable using the `TF_REATTACH_PROVIDERS` from above. Create it like this on Windows: `set TF_REATTACH_PROVIDERS='{"registry.terraform.io/dell/redfish":{"Protocol":"grpc","Pid":32044,"Test":true,"Addr":{"Network":"tcp","String":"127.0.0.1:51865"}}}'`
+9. Run your Terraform commands as usual.

--- a/docs/PROVIDER.md
+++ b/docs/PROVIDER.md
@@ -2,7 +2,7 @@
 This guide will explain different parts of the provider and will give an overview about how the provider is built, to onboard quicker developers that might be interested in this project.  
 
 ## 1. Provider's way of operation
-When you think of Terraform, normally operators tend to think that the way a provider connects with a cloud provider is via a single endpoint. Well, actually that's the way it works. Cloud providers provide and endpoint and operators point to that endpoint when configuring terraform.  
+When you think of Terraform, normally operators tend to think that the way a provider connects with a cloud provider is via a single endpoint. Well, actually that's the way it works. Cloud providers provide an endpoint and operators point to that endpoint when configuring terraform.  
 ~~~
   +-----------------+
   | Cloud provider  |
@@ -33,8 +33,9 @@ In a regular scenario (for instance a datacenter), operators don't just have one
 
 ~~~
 
-## How this is overcomed
-Normally the provider is initialized in the provider block, giving it your cloud credentials to deal with the infra. Something like this:
+## How we overcome this
+
+Normally the provider is initialized in the provider block, giving it your cloud credentials to deal with the infrastructure. Something like this:
 ~~~	
 provider "aws" {
 	region     = "eu-west-1"
@@ -42,10 +43,10 @@ provider "aws" {
 	secret_key = "mysecretkey"
 }
 ~~~
-When that is done, then operators would start writing the resources wanted to be deployed in there.  
+When that is done, then operators would start writing the resources they want to deploy in those regions.  
 
   
-With this **terraform redfish provider** a different approach had to be followed since there are multiple endpoints. What has been done (and kudos to Kyriakos Oikonomakos from Hashicorp to propose this) was to initialize the client at resource level. This allow operators to manage different servers in one shot. Take a look into this example:  
+With this **terraform redfish provider** a different approach had to be followed since there are multiple endpoints. What has been done (and kudos to Kyriakos Oikonomakos from Hashicorp for proposing this) was to initialize the client at the resource level. This allows operators to manage different servers from one central point. Take a look into this example:  
     
 users.tf
 ~~~
@@ -86,18 +87,19 @@ rack1 = {
 }
 ~~~
   
-By following this, operators will be creating two users in two different servers, using this provider and the Redfish API.  
+By doing this, operators create two users on two different servers using this provider and the Redfish API.  
 *Remember, in every CRUD operation, the client must be initialized.*
 
-## Overwriding client credentials
-There might be scenarios where operators have the same credentials for all machines to be managed. In that case they don't need to write over and over again the *user* and *password* for all servers. There credentials can be written at provider block level. 
+## Overwriting client credentials
+There might be scenarios where operators have the same credentials for all machines they want to manage. In that case they don't need to repeatedly write the *user* and *password* for all servers. They can write their credentials at the provider block level.
 ~~~
 provider "redfish" {
     user = "root"
     password = "calvin"
 }
 ~~~
-And then, when defining the infrastructure, just add the *endpoint* and *ssl_insecure* values:
+
+After the user specifies their credentials, they will next need to define the infrastructure. Instead of defining credentials for each endpoint they need only provide the *endpoint* and *ssl_insecure* values:
 
 ~~~
 rack1 = {
@@ -112,5 +114,5 @@ rack1 = {
 }
 ~~~
 
-Also, the rule for this is to use the most specific client values, so in case the client credentials are placed at both, provider block and resource level, **the ones defined at resource level** will be used. 
+Terraform will always use the most specific client values. In the case client credentials are defined at both the provider block and resource level, **the credentials defined at the resource level** will be used. 
   

--- a/main.go
+++ b/main.go
@@ -1,11 +1,34 @@
 package main
 
 import (
+	"context"
+
+	"flag"
+	"log"
+
 	"github.com/dell/terraform-provider-redfish/redfish"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: redfish.Provider})
+
+	var debugMode bool
+
+	// Set this flag to true if you want the provider to run in debug mode. Leaving it as is will cause it to run
+	// normally.
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: redfish.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/dell/redfish", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
+
 }

--- a/redfish/config.go
+++ b/redfish/config.go
@@ -24,7 +24,7 @@ func NewConfig(provider *schema.ResourceData, resource *schema.ResourceData) (*g
 
 	resourceServerConfig := resource.Get("redfish_server").([]interface{}) //It must be just one element
 
-	//Overwride parameters (just user and password for client connection)
+	//Overwrite parameters (just user and password for client connection)
 	//Get redfish username at resource level over provider level
 	var redfishClientUser, redfishClientPass string
 	if len(resourceServerConfig[0].(map[string]interface{})["user"].(string)) > 0 {


### PR DESCRIPTION
PROVIDER.md:
- Fixed minor grammatical errors (ex: an vs and, their vs there)
- Replaced mixtures of the infinitive/gerund/past participle
- Changed non-standard uses of passive voice
- Added missing articles

CONTRIBUTING.md:
- Added a section on how to set up a debugger using GoLand
- Added a pointer to the providers tutorial to help people get started

config.go:
- Fixed a type-o

main.go:
- Added the ability to put the provider in debug mode by changing a flag

Signed-off-by: Grant Curell <grant_curell@dell.com>