### PR TITLE
issue_number #19: Added idempotency support for Bios

### DIFF
--- a/examples/bios/bios.tf
+++ b/examples/bios/bios.tf
@@ -25,7 +25,7 @@ resource "redfish_bios" "bios" {
     "NumLock" = "On"
   }
   settings_apply_time = "OnReset"
-  //action_after_apply = "ForceRestart"
+  reset_type = "ForceRestart"
 }
 
 data "redfish_bios" "bios" {

--- a/redfish/resource_redfish_bios.go
+++ b/redfish/resource_redfish_bios.go
@@ -222,7 +222,7 @@ func updateRedfishBiosResource(service *gofish.Service, d *schema.ResourceData) 
 
 		if v, ok := d.GetOk("task_monitor_uri"); ok {
 			log.Printf("[DEBUG] %s: Bios config task monitor uri is \"%s\"", d.Id(), v.(string))
-			taskURI, _ = v.(string)
+			taskURI, _ := v.(string)
 			if len(taskURI) > 0 {
 				createStateConf := &resource.StateChangeConf{
 					Pending: []string{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added idempotency support for the redfish BIOS resource 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #19 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_resource_bios

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
**_After:_**
```paste below

$ terraform apply
redfish_bios.bios["my-server-2"]: Refreshing state... [id=/redfish/v1/Systems/System.Embedded.1/Bios]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added idempotency support for redfish bios resource
```

#### Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
