### PR TITLE
MutexKV implemented in all resources

### DIFF
--- a/mutexkv/mutexkv.go
+++ b/mutexkv/mutexkv.go
@@ -1,0 +1,51 @@
+package mutexkv
+
+import (
+	"log"
+	"sync"
+)
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It must be used
+// when creating resources, since some of them might restart the servers.
+// Not using MutexKV might lead to inconsistances because some resources
+// might reace each other.
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Lock the mutex for the given key. The caller is responsible for calling
+// Unlock for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %s", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %s", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the
+// same key first.
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %s", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %s", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+
+	}
+	return mutex
+}
+
+// NewMutexKV returns a properly initialized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/mutexkv/mutexkv_test.go
+++ b/mutexkv/mutexkv_test.go
@@ -1,0 +1,58 @@
+package mutexkv
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMutexKV(t *testing.T) {
+	var sum1 int = 0
+	var sum2 int = 0
+	mutex := NewMutexKV()
+	t.Run("test Mutex with two users", func(t *testing.T) {
+		wg := &sync.WaitGroup{}
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			wggo := &sync.WaitGroup{}
+			wggo.Add(10)
+			for i := 0; i < 10; i++ {
+				go func(number int) {
+					defer wggo.Done()
+					mutex.Lock("test")
+					defer mutex.Unlock("test")
+					sum1 += number
+				}(i)
+			}
+			wggo.Wait()
+		}()
+
+		go func() {
+			defer wg.Done()
+			wggo := &sync.WaitGroup{}
+			wggo.Add(5)
+			for i := 5; i < 10; i++ {
+				go func(number int) {
+					defer wggo.Done()
+					mutex.Lock("test2")
+					defer mutex.Unlock("test2")
+					sum2 += number
+				}(i)
+			}
+			wggo.Wait()
+		}()
+
+		wg.Wait()
+		assertSum(t, sum1, 45)
+		assertSum(t, sum2, 35)
+	})
+
+}
+
+func assertSum(t testing.TB, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("the sum wasn't done correctly. Got %d, want %d", got, want)
+	}
+}

--- a/redfish/common.go
+++ b/redfish/common.go
@@ -3,12 +3,13 @@ package redfish
 import (
 	"errors"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/redfish"
-	"log"
-	"time"
 )
 
 // Based on an instance of Service from the gofish library, retrieve a concrete system on which we can take action
@@ -158,4 +159,12 @@ func PowerOperation(resetType string, maximumWaitTime int, checkInterval int, se
 	log.Printf("[ERROR]: The system failed to correctly update the system power!")
 	return system.PowerState, diags
 
+}
+
+// getRedfishServerEndpoint returns the endpoint from an schema. This might be useful
+// when using MutexKV, since we need a way to differentiate mutex operations
+// across servers
+func getRedfishServerEndpoint(resource *schema.ResourceData) string {
+	resourceServerConfig := resource.Get("redfish_server").([]interface{})
+	return resourceServerConfig[0].(map[string]interface{})["endpoint"].(string)
 }

--- a/redfish/provider.go
+++ b/redfish/provider.go
@@ -1,8 +1,13 @@
 package redfish
 
 import (
+	"github.com/dell/terraform-provider-redfish/mutexkv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// This is a global MutexKV for use within this plugin
+var redfishMutexKV = mutexkv.NewMutexKV()
 
 func Provider() *schema.Provider {
 	provider := &schema.Provider{

--- a/redfish/resource_redfish_power.go
+++ b/redfish/resource_redfish_power.go
@@ -2,9 +2,10 @@ package redfish
 
 import (
 	"context"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
 )
 
 func resourceRedFishPower() *schema.Resource {
@@ -140,6 +141,10 @@ func resourceRedfishPowerRead(ctx context.Context, d *schema.ResourceData, m int
 func resourceRedfishPowerUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 	var diags diag.Diagnostics
+
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
 
 	resetType, ok := d.GetOk("desired_power_action")
 

--- a/redfish/resource_redfish_simple_update.go
+++ b/redfish/resource_redfish_simple_update.go
@@ -180,6 +180,10 @@ func readRedfishSimpleUpdate(service *gofish.Service, d *schema.ResourceData) di
 func updateRedfishSimpleUpdate(ctx context.Context, service *gofish.Service, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
+
 	transferProtocol := d.Get("transfer_protocol").(string)
 	targetFirmwareImage := d.Get("target_firmware_image").(string)
 	resetType := d.Get("reset_type").(string)

--- a/redfish/resource_redfish_user_account.go
+++ b/redfish/resource_redfish_user_account.go
@@ -109,6 +109,11 @@ func resourceRedfishUserAccountDelete(ctx context.Context, d *schema.ResourceDat
 
 func createRedfishUserAccount(service *gofish.Service, d *schema.ResourceData) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
+
 	accountList, err := getAccountList(service)
 	if err != nil {
 		return diag.Errorf("Error when retrieving account list %v", err)
@@ -167,6 +172,11 @@ func readRedfishUserAccount(service *gofish.Service, d *schema.ResourceData) dia
 
 func updateRedfishUserAccount(ctx context.Context, service *gofish.Service, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
+
 	accountList, err := getAccountList(service)
 	if err != nil {
 		return diag.Errorf("Error when retrieving account list %v", err)
@@ -195,6 +205,11 @@ func updateRedfishUserAccount(ctx context.Context, service *gofish.Service, d *s
 
 func deleteRedfishUserAccount(service *gofish.Service, d *schema.ResourceData) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
+
 	accountList, err := getAccountList(service)
 	if err != nil {
 		return diag.Errorf("Error when retrieving account list %v", err)

--- a/redfish/resource_redfish_virtual_media.go
+++ b/redfish/resource_redfish_virtual_media.go
@@ -134,6 +134,10 @@ func resourceRedfishVirtualMediaDelete(ctx context.Context, d *schema.ResourceDa
 func createRedfishVirtualMedia(service *gofish.Service, d *schema.ResourceData) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
+
 	//Get terraform schema data
 	virtualMediaID := d.Get("virtual_media_id").(string)
 	image := d.Get("image").(string)
@@ -275,6 +279,10 @@ func readRedfishVirtualMedia(service *gofish.Service, d *schema.ResourceData) di
 func updateRedfishVirtualMedia(ctx context.Context, service *gofish.Service, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
+
 	//Hot update os not possible. Unmount and mount needs to be done to update
 	virtualMedia, err := redfish.GetVirtualMedia(service.Client, d.Id())
 	if err != nil {
@@ -338,6 +346,10 @@ func updateRedfishVirtualMedia(ctx context.Context, service *gofish.Service, d *
 
 func deleteRedfishVirtualMedia(service *gofish.Service, d *schema.ResourceData) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	// Lock the mutex to avoid race conditions with other resources
+	redfishMutexKV.Lock(getRedfishServerEndpoint(d))
+	defer redfishMutexKV.Unlock(getRedfishServerEndpoint(d))
 
 	virtualMedia, err := redfish.GetVirtualMedia(service.Client, d.Id())
 	if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #40 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
All resources

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Every time a changing operation is done in a server, the resource in charge tries to acquire a lock that prevents other resources that want to perform changes in the same server to do so at the same time (race condition).

This Mutex must be used in all server changing operations, no matter if they restart the server or not. 
If an operation (like the delete ones) does not perform any changes and it only change the statefile (like getting rid of the ID), this lock must not be used.

The lock store will have as many locks as servers are being managed by the provider. 
The lock store is a map where the key is the server endpoint, while the value is a pointer to the server Mutex. 
Also, a new function has been created in the redfish package (common.go) to help getting the server endpoint passing the resource schema:
~~~
func getEndpointFromSchema(resource *schema.ResourceData) string
~~~

The mutex MUST be used at the beginning of all Create/Update/Delete operations that actually carry out any changes in the servers. 

mutexkv is a global variable created and initialized in provider.go file.

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- mutexkv package created (with tests)
- Modified all current resources to use mutexkv
```

<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
