### PR TITLE
Added data source for Redfish ComputerSystem Boot resource

### DIFF
--- a/examples/boot/boot.tf
+++ b/examples/boot/boot.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    redfish = {
+      source = "dellemc/redfish"
+      version = "~> 0.2.0"
+    }
+  }
+}
+
+provider "redfish" {
+    //user = "admin"
+    //password = "passw0rd"
+}
+
+data "redfish_system_boot" "system_boot" {
+  for_each = var.rack1
+
+  redfish_server {
+    user = each.value.user
+    password = each.value.password
+    endpoint = each.value.endpoint
+    ssl_insecure = each.value.ssl_insecure
+  }
+
+  // resource_id is an optional argument. By default, the data source uses
+  // the first ComputerSystem resource present in the ComputerSystem collection
+  resource_id = "System.Embedded.1"
+}
+
+output "system_boot" {
+  value = data.redfish_system_boot.system_boot
+  sensitive = true
+}

--- a/examples/boot/terraform.tfvars
+++ b/examples/boot/terraform.tfvars
@@ -1,0 +1,14 @@
+rack1 = {
+    "my-server-1" = {
+        user = "admin"
+        password = "passw0rd"
+        endpoint = "https://my-server-1.myawesomecompany.org"
+        ssl_insecure = true
+    },
+    "my-server-2" = {
+        user = "admin"
+        password = "passw0rd"
+        endpoint = "https://my-server-2.myawesomecompany.org"
+        ssl_insecure = true
+    },
+}

--- a/examples/boot/vars.tf
+++ b/examples/boot/vars.tf
@@ -1,0 +1,8 @@
+variable "rack1" {
+  type = map(object({
+    user         = string
+    password     = string
+    endpoint     = string
+    ssl_insecure = bool
+  }))
+}

--- a/redfish/data_source_redfish_system_boot.go
+++ b/redfish/data_source_redfish_system_boot.go
@@ -1,0 +1,149 @@
+package redfish
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/redfish"
+)
+
+func dataSourceRedfishSystemBoot() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRedfishSystemBootRead,
+		Schema:      getDataSourceRedfishSystemBootSchema(),
+	}
+}
+
+func getDataSourceRedfishSystemBootSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"redfish_server": {
+			Type:        schema.TypeList,
+			Required:    true,
+			Description: "List of server BMCs and their respective user credentials",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"user": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "User name for login",
+					},
+					"password": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "User password for login",
+						Sensitive:   true,
+					},
+					"endpoint": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Server BMC IP address or hostname",
+					},
+					"ssl_insecure": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "This field indicates whether the SSL/TLS certificate must be verified or not",
+					},
+				},
+			},
+		},
+		"resource_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Resource ID of the computer system resource. If not provided, then the first system resource is used from the computer system collection",
+		},
+		"boot_order": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "An array of BootOptionReference strings that represent the persistent boot order for this computer system",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"boot_source_override_enabled": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The state of the boot source override feature",
+		},
+		"boot_source_override_mode": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The BIOS boot mode to use when the system boots from the BootSourceOverrideTarget boot source",
+		},
+		"boot_source_override_target": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The current boot source to use at the next boot instead of the normal boot device, if BootSourceOverrideEnabled is true",
+		},
+		"uefi_target_boot_source_override": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The UEFI device path of the device from which to boot when BootSourceOverrideTarget is UefiTarget",
+		},
+	}
+}
+
+func dataSourceRedfishSystemBootRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	service, err := NewConfig(m.(*schema.ResourceData), d)
+	if err != nil {
+		return diag.Errorf(err.Error())
+	}
+
+	return readRedfishSystemBoot(service, d)
+}
+
+func readRedfishSystemBoot(service *gofish.Service, d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	systems, err := service.Systems()
+	if err != nil {
+		return diag.Errorf("Error when retrieving systems: %s", err)
+	}
+
+	// get the boot resource
+	var computerSystem *redfish.ComputerSystem
+	var boot redfish.Boot
+	if systemResourceId, ok := d.GetOk("resource_id"); ok {
+		for key := range systems {
+			if systems[key].ID == systemResourceId {
+				computerSystem = systems[key]
+				boot = systems[key].Boot
+				break
+			}
+		}
+
+		if computerSystem == nil {
+			return diag.Errorf("Could not find a ComputerSystem resource with resource ID = %s", systemResourceId)
+		}
+	} else {
+		// use the first system resource in the collection if resource
+		// ID is not provided
+		computerSystem = systems[0]
+		boot = systems[0].Boot
+	}
+
+	if err := d.Set("boot_order", boot.BootOrder); err != nil {
+		return diag.Errorf("error setting BootOrder: %s", err)
+	}
+
+	if err := d.Set("boot_source_override_enabled", boot.BootSourceOverrideEnabled); err != nil {
+		return diag.Errorf("error setting BootSourceOverrideEnabled: %s", err)
+	}
+
+	if err := d.Set("boot_source_override_mode", boot.BootSourceOverrideMode); err != nil {
+		return diag.Errorf("error setting BootSourceOverrideMode: %s", err)
+	}
+
+	if err := d.Set("boot_source_override_target", boot.BootSourceOverrideTarget); err != nil {
+		return diag.Errorf("error setting BootSourceOverrideTarget: %s", err)
+	}
+
+	if err := d.Set("uefi_target_boot_source_override", boot.UefiTargetBootSourceOverride); err != nil {
+		return diag.Errorf("error setting UefiTargetBootSourceOverride: %s", err)
+	}
+
+	// set computer system ODataID as the resource ID
+	d.SetId(computerSystem.ODataID)
+	return diags
+}

--- a/redfish/provider.go
+++ b/redfish/provider.go
@@ -40,6 +40,7 @@ func Provider() *schema.Provider {
 			"redfish_storage":               dataSourceRedfishStorage(),
 			"redfish_firmware_inventory":    dataSourceRedfishFirmwareInventory(),
 			"redfish_dell_idrac_attributes": dataSourceRedfishDellIdracAttributes(),
+			"redfish_system_boot":           dataSourceRedfishSystemBoot(),
 		},
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added data source for Redfish ComputerSystem Boot resource

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #39 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
data_source_redfish_system_boot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ terraform apply


Changes to Outputs:
  + system_boot = (sensitive value)

You can apply this plan to save these new output values to the Terraform state,
without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

system_boot = <sensitive>

```
   **_terraform.tfstate_**
```
{
  "version": 4,
  "terraform_version": "1.0.2",
  "serial": 2,
  "lineage": "6372e915-e955-ce2f-a5d7-2f97ab2568c5",
  "outputs": {
    "system_boot": {
      "value": {
        "my-server-1": {
          "boot_order": [
            "Boot0008",
            "Boot0002",
            "Boot0001",
            "Boot0003",
            "Boot0004",
            "Boot0005",
            "Boot000A"
          ],
          "boot_source_override_enabled": "Disabled",
          "boot_source_override_mode": "UEFI",
          "boot_source_override_target": "None",
          "id": "/redfish/v1/Systems/System.Embedded.1",
          "redfish_server": [
            {
              "endpoint": "https://my-server-1.myawesomecompany.org",
              "password": "passw0rd",
              "ssl_insecure": true,
              "user": "admin"
            }
          ],
          "resource_id": "System.Embedded.1",
          "uefi_target_boot_source_override": ""
        }
      },
...
<SNIPPED FOR BREVITY>
...
```

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added a new Data Source for Redfish ComputerSystem Boot resource

```

#### Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
