### PR TITLE
Added acceptance test for virtual media datasource

### DIFF
--- a/redfish/data_source_redfish_virtual_media_test.go
+++ b/redfish/data_source_redfish_virtual_media_test.go
@@ -1,0 +1,42 @@
+package redfish
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccRedfishVirtualMedia_fetch(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedfishDatasourceVirtualMediaConfig(creds),
+			},
+		},
+	})
+}
+
+func testAccRedfishDatasourceVirtualMediaConfig(testingInfo TestingServerCredentials) string {
+	return fmt.Sprintf(`
+	data "redfish_virtual_media" "vm" {
+	  
+		redfish_server {
+		  user         = "%s"
+		  password     = "%s"
+		  endpoint     = "https://%s"
+		  ssl_insecure = true
+		}
+	  }
+	  
+	  output "virtual_media" {
+		 value = data.redfish_virtual_media.vm
+		 sensitive = true
+	  }
+	`,
+		testingInfo.Username,
+		testingInfo.Password,
+		testingInfo.Endpoint,
+	)
+}


### PR DESCRIPTION
```
# make testacc TESTARGS='-run=TestAccRedfishVirtualMedia_fetch'
TF_ACC=1 go test $(go list ./... | grep -v 'vendor') -v -run=TestAccRedfishVirtualMedia_fetch -timeout 120m
?       github.com/dell/terraform-provider-redfish      [no test files]
?       github.com/dell/terraform-provider-redfish/common       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/dell/terraform-provider-redfish/gofish/dell  0.006s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/dell/terraform-provider-redfish/mutexkv      0.012s [no tests to run]
=== RUN   TestAccRedfishVirtualMedia_fetch
--- PASS: TestAccRedfishVirtualMedia_fetch (11.01s)
PASS
ok      github.com/dell/terraform-provider-redfish/redfish      11.022s

```

![image](https://github.com/dell/terraform-provider-redfish/assets/117063742/c5cb4521-a7cd-4aff-9094-bbbdf778e0d7)
