### PR TITLE
Fixing drives validation

### DIFF
--- a/redfish/resource_redfish_storage_volume.go
+++ b/redfish/resource_redfish_storage_volume.go
@@ -230,8 +230,11 @@ func createRedfishStorageVolume(service *gofish.Service, d *schema.ResourceData)
 
 	// Convert from []interface{} to []string for using
 	driveNames := make([]string, len(driveNamesRaw))
+	if len(driveNamesRaw) == 0 {
+		return diag.Errorf("Error when getting the drives: drives cannot be empty")
+	}
 	for i, raw := range driveNamesRaw {
-		if len(raw.(string)) == 0 {
+		if raw == nil {
 			return diag.Errorf("Error when getting the drives: drive name cannot be blank")
 		}
 		driveNames[i] = raw.(string)
@@ -363,8 +366,11 @@ func updateRedfishStorageVolume(ctx context.Context, service *gofish.Service, d 
 
 	// Convert from []interface{} to []string for using
 	driveNames := make([]string, len(driveNamesRaw))
+	if len(driveNamesRaw) == 0 {
+		return diag.Errorf("Error when getting the drives: drives cannot be empty")
+	}
 	for i, raw := range driveNamesRaw {
-		if len(raw.(string)) == 0 {
+		if raw == nil {
 			return diag.Errorf("Error when getting the drives: drive name cannot be blank")
 		}
 		driveNames[i] = raw.(string)


### PR DESCRIPTION
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # redfish_storage_volume.volume["my-server-1"] will be updated in-place
  ~ resource "redfish_storage_volume" "volume" {
      ~ drives                = [
          - "Solid State Disk 0:0:1",
          - "",
        ]
        id                    = "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes/Disk.Virtual.0:RAID.Integrated.1-1"
        # (12 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

redfish_storage_volume.volume["my-server-1"]: Modifying... [id=/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes/Disk.Virtual.0:RAID.Integrated.1-1]
╷
│ Error: Error when getting the drives: drives cannot be empty
│
│   with redfish_storage_volume.volume["my-server-1"],
│   on volume.tf line 12, in resource "redfish_storage_volume" "volume":
│   12: resource "redfish_storage_volume" "volume" {
│

```


```
  ~ update in-place

Terraform will perform the following actions:

  # redfish_storage_volume.volume["my-server-1"] will be updated in-place
  ~ resource "redfish_storage_volume" "volume" {
      ~ drives                = [
            "Solid State Disk 0:0:1",
          + "",
        ]
        id                    = "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes/Disk.Virtual.0:RAID.Integrated.1-1"
        # (12 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

redfish_storage_volume.volume["my-server-1"]: Modifying... [id=/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes/Disk.Virtual.0:RAID.Integrated.1-1]
╷
│ Error: Error when getting the drives: drive name cannot be blank
│
│   with redfish_storage_volume.volume["my-server-1"],
│   on volume.tf line 12, in resource "redfish_storage_volume" "volume":
│   12: resource "redfish_storage_volume" "volume" {
│
╵

```