### PR TITLE
Fixing virtual media and idrac attributes resource

### DIFF
--- a/redfish/provider/resource_redfish_dell_idrac_attributes.go
+++ b/redfish/provider/resource_redfish_dell_idrac_attributes.go
@@ -101,6 +101,9 @@ func (r *dellIdracAttributesResource) Create(ctx context.Context, req resource.C
 
 	diags = updateRedfishDellIdracAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "resource_DellIdracAttributes create: updating state finished, saving ...")
 	// Save into State
@@ -127,6 +130,10 @@ func (r *dellIdracAttributesResource) Read(ctx context.Context, req resource.Rea
 
 	diags = readRedfishDellIdracAttributes(ctx, service, &state)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	tflog.Trace(ctx, "resource_DellIdracAttributes read: finished reading state")
 	// Save into State
 	diags = resp.State.Set(ctx, &state)
@@ -155,6 +162,9 @@ func (r *dellIdracAttributesResource) Update(ctx context.Context, req resource.U
 
 	diags = updateRedfishDellIdracAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "resource_DellIdracAttributes update: finished state update")
 	// Save into State

--- a/redfish/provider/resource_redfish_virtual_media.go
+++ b/redfish/provider/resource_redfish_virtual_media.go
@@ -287,7 +287,7 @@ func (r *virtualMediaResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// Get service
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	service, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return


### PR DESCRIPTION
1. Fixed bug with virtual media where server credentials were getting read from state instead of plan in update.
2. Fixed bug with iDRAC attributes resource where it didn't returned after error.