### PR TITLE
Fix storage volume import test

### DIFF
--- a/redfish/provider/resource_redfish_storage_volume.go
+++ b/redfish/provider/resource_redfish_storage_volume.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"terraform-provider-redfish/common"
 	"terraform-provider-redfish/redfish/models"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -486,6 +487,7 @@ func createRedfishStorageVolume(ctx context.Context, service *gofish.Service, d 
 		diags.AddError(RedfishJobErrorMsg, err.Error())
 		return diags
 	}
+	time.Sleep(60 * time.Second)
 
 	// Get storage volumes
 	volumes, err := storage.Volumes()
@@ -623,6 +625,7 @@ func updateRedfishStorageVolume(ctx context.Context, service *gofish.Service,
 		diags.AddError(RedfishJobErrorMsg, err.Error())
 		return diags
 	}
+	time.Sleep(60 * time.Second)
 
 	// Get storage volumes
 	volumes, err := storage.Volumes()

--- a/redfish/provider/resource_redfish_storage_volume_test.go
+++ b/redfish/provider/resource_redfish_storage_volume_test.go
@@ -99,6 +99,59 @@ func TestAccRedfishStorageVolume_InvalidVolumeType(t *testing.T) {
 		},
 	})
 }
+func TestAccRedfishStorageVolumeUpdate_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedfishResourceStorageVolumeConfig(
+					creds,
+					"RAID.Integrated.1-1",
+					"TerraformVol1",
+					"NonRedundant",
+					drive,
+					"Immediate",
+					"AdaptiveReadAhead",
+					"UnprotectedWriteBack",
+					"PowerCycle",
+					100,
+					1200,
+					1073323222,
+					131072,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "storage_controller_id", "RAID.Integrated.1-1"),
+					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "read_cache_policy", "AdaptiveReadAhead"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+
+			{
+				Config: testAccRedfishResourceStorageVolumeConfig(
+					creds,
+					"RAID.Integrated.1-1",
+					"TerraformVol1",
+					"NonRedundant",
+					drive,
+					"Immediate",
+					"ReadAhead",
+					"UnprotectedWriteBack",
+					"PowerCycle",
+					100,
+					1200,
+					1073323222,
+					131072,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "storage_controller_id", "RAID.Integrated.1-1"),
+					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "read_cache_policy", "ReadAhead"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 
 func TestAccRedfishStorageVolumeCreate_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -172,60 +225,6 @@ func TestAccRedfishStorageVolume_basic(t *testing.T) {
 	})
 }
 
-func TestAccRedfishStorageVolumeUpdate_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRedfishResourceStorageVolumeConfig(
-					creds,
-					"RAID.Integrated.1-1",
-					"TerraformVol1",
-					"NonRedundant",
-					drive,
-					"Immediate",
-					"AdaptiveReadAhead",
-					"UnprotectedWriteBack",
-					"PowerCycle",
-					100,
-					1200,
-					1073323222,
-					131072,
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "storage_controller_id", "RAID.Integrated.1-1"),
-					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "read_cache_policy", "AdaptiveReadAhead"),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-
-			{
-				Config: testAccRedfishResourceStorageVolumeConfig(
-					creds,
-					"RAID.Integrated.1-1",
-					"TerraformVol1",
-					"NonRedundant",
-					drive,
-					"Immediate",
-					"ReadAhead",
-					"UnprotectedWriteBack",
-					"PowerCycle",
-					100,
-					1200,
-					1073323222,
-					131072,
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "storage_controller_id", "RAID.Integrated.1-1"),
-					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "read_cache_policy", "ReadAhead"),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
 func TestAccRedfishStorageVolume_OnReset(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -251,6 +250,7 @@ func TestAccRedfishStorageVolume_OnReset(t *testing.T) {
 					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "storage_controller_id", "RAID.Integrated.1-1"),
 					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "write_cache_policy", "UnprotectedWriteBack"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
```
=== RUN   TestAccRedfishStorageVolume_InvalidController
--- PASS: TestAccRedfishStorageVolume_InvalidController (2.92s)
=== RUN   TestAccRedfishStorageVolume_InvalidDrive
--- PASS: TestAccRedfishStorageVolume_InvalidDrive (4.24s)
=== RUN   TestAccRedfishStorageVolume_InvalidVolumeType
--- PASS: TestAccRedfishStorageVolume_InvalidVolumeType (4.86s)
=== RUN   TestAccRedfishStorageVolumeUpdate_basic
--- PASS: TestAccRedfishStorageVolumeUpdate_basic (434.45s)
=== RUN   TestAccRedfishStorageVolumeCreate_basic
--- PASS: TestAccRedfishStorageVolumeCreate_basic (274.10s)
=== RUN   TestAccRedfishStorageVolume_basic
--- PASS: TestAccRedfishStorageVolume_basic (272.45s)
=== RUN   TestAccRedfishStorageVolume_OnReset
--- PASS: TestAccRedfishStorageVolume_OnReset (469.34s)
PASS
```