### PR TITLE
boot source override updated

### DIFF
--- a/docs/resources/boot_source_override.md
+++ b/docs/resources/boot_source_override.md
@@ -118,7 +118,7 @@ limitations under the License.
 terraform {
   required_providers {
     redfish = {
-      version = "1.1.0"
+      version = "1.2.0"
       source  = "registry.terraform.io/dell/redfish"
     }
   }

--- a/examples/resources/redfish_boot_source_override/provider.tf
+++ b/examples/resources/redfish_boot_source_override/provider.tf
@@ -18,7 +18,7 @@ limitations under the License.
 terraform {
   required_providers {
     redfish = {
-      version = "1.1.0"
+      version = "1.2.0"
       source  = "registry.terraform.io/dell/redfish"
     }
   }

--- a/redfish/provider/resource_redfish_boot_sources_override.go
+++ b/redfish/provider/resource_redfish_boot_sources_override.go
@@ -262,9 +262,7 @@ func (*BootSourceOverrideResource) Read(ctx context.Context, req resource.ReadRe
 	tflog.Trace(ctx, "resource_Boot_source Read: finish")
 }
 
-func (r *BootSourceOverrideResource) bootOperation(ctx context.Context, service *gofish.Service,
-	plan *models.BootSourceOverride,
-) diag.Diagnostics {
+func (r *BootSourceOverrideResource) bootOperation(ctx context.Context, service *gofish.Service, plan *models.BootSourceOverride) diag.Diagnostics {
 	// Lock the mutex to avoid race conditions with other resources
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
@@ -298,9 +296,7 @@ func (r *BootSourceOverrideResource) bootOperation(ctx context.Context, service 
 		return diags
 	}
 
-	if plan.BootSourceOverrideMode.ValueString() != "" && plan.BootSourceOverrideMode.ValueString() != string(system.Boot.BootSourceOverrideMode) {
-		diags.Append(r.restartServer(ctx, service, resp, plan)...)
-	}
+	diags.Append(r.restartServer(ctx, service, resp, plan)...)
 	return diags
 }
 


### PR DESCRIPTION
Added reboot for every case.
```
=== RUN   TestAccRedfishBootSourceOverride_basic
--- PASS: TestAccRedfishBootSourceOverride_basic (532.36s)
=== RUN   TestAccRedfishBootSourceOverride_updated
--- PASS: TestAccRedfishBootSourceOverride_updated (595.16s)
PASS
```
<img width="491" alt="image" src="https://github.com/dell/terraform-provider-redfish/assets/75004921/4d073af6-fae2-48c8-bb6d-d674d3463634">
