### PR TITLE
Adding drive_ids field to storage datasource 

### DIFF
--- a/docs/data-sources/storage.md
+++ b/docs/data-sources/storage.md
@@ -193,7 +193,8 @@ Optional:
 Read-Only:
 
 - `description` (String) description of the storage
-- `drives` (List of String) drives on the storage
+- `drive_ids` (List of String) IDs of drives on the storage
+- `drives` (List of String) Names of drives on the storage
 - `name` (String) name of the storage
 - `oem` (Attributes) oem attributes of storage controller (see [below for nested schema](#nestedatt--storage--oem))
 - `status` (Attributes) status of the storage (see [below for nested schema](#nestedatt--storage--status))

--- a/docs/data-sources/storage.md
+++ b/docs/data-sources/storage.md
@@ -194,7 +194,7 @@ Read-Only:
 
 - `description` (String) description of the storage
 - `drive_ids` (List of String) IDs of drives on the storage
-- `drives` (List of String) Names of drives on the storage
+- `drives` (List of String) Names of drives on the storage. They are in same order as in `drive_ids`, ie. `drives[i]` will be the name of the drive whose ID is given by `drive_ids[i].`
 - `name` (String) name of the storage
 - `oem` (Attributes) oem attributes of storage controller (see [below for nested schema](#nestedatt--storage--oem))
 - `status` (Attributes) status of the storage (see [below for nested schema](#nestedatt--storage--status))

--- a/redfish/models/storage.go
+++ b/redfish/models/storage.go
@@ -17,6 +17,7 @@ type StorageDatasource struct {
 type Storage struct {
 	ID                 types.String         `tfsdk:"storage_controller_id"`
 	Drives             []types.String       `tfsdk:"drives"`
+	DriveIDs           []types.String       `tfsdk:"drive_ids"`
 	Description        types.String         `tfsdk:"description"`
 	Name               types.String         `tfsdk:"name"`
 	Oem                Oem                  `tfsdk:"oem"`

--- a/redfish/provider/data_source_redfish_storage.go
+++ b/redfish/provider/data_source_redfish_storage.go
@@ -315,10 +315,12 @@ func StorageSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"drives": schema.ListAttribute{
-			MarkdownDescription: "Names of drives on the storage",
-			Description:         "Names of drives on the storage",
-			Computed:            true,
-			ElementType:         types.StringType,
+			MarkdownDescription: "Names of drives on the storage. They are in same order as in `drive_ids`, ie." +
+				" `drives[i]` will be the name of the drive whose ID is given by `drive_ids[i].`",
+			Description: "Names of drives on the storage. They are in same order as in 'drive_ids', ie." +
+				" 'drives[i]' will be the name of the drive whose ID is given by 'drive_ids[i].'",
+			Computed:    true,
+			ElementType: types.StringType,
 		},
 		"drive_ids": schema.ListAttribute{
 			MarkdownDescription: "IDs of drives on the storage",

--- a/redfish/provider/data_source_redfish_storage.go
+++ b/redfish/provider/data_source_redfish_storage.go
@@ -145,9 +145,12 @@ func (g *StorageDatasource) readDatasourceRedfishStorage(d models.StorageDatasou
 		}
 
 		driveNames := make([]types.String, 0)
+		driveIDs := make([]types.String, 0)
 		for _, d := range drives {
+			driveIDs = append(driveIDs, types.StringValue(d.ID))
 			driveNames = append(driveNames, types.StringValue(d.Name))
 		}
+		terraformData.DriveIDs = driveIDs
 		terraformData.Drives = driveNames
 		d.Storages = append(d.Storages, terraformData)
 	}
@@ -312,8 +315,14 @@ func StorageSchema() map[string]schema.Attribute {
 			Computed:            true,
 		},
 		"drives": schema.ListAttribute{
-			MarkdownDescription: "drives on the storage",
-			Description:         "drives on the storage",
+			MarkdownDescription: "Names of drives on the storage",
+			Description:         "Names of drives on the storage",
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"drive_ids": schema.ListAttribute{
+			MarkdownDescription: "IDs of drives on the storage",
+			Description:         "IDs of drives on the storage",
 			Computed:            true,
 			ElementType:         types.StringType,
 		},


### PR DESCRIPTION
Tested via module that pdisk ids are returned
```
pdisk_fqdds  = [
               "Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1",
               "Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1",
               "Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1",
            ]
```