### PR TITLE
Storage Volume Enhancement

### DIFF
--- a/docs/resources/storage_volume.md
+++ b/docs/resources/storage_volume.md
@@ -116,8 +116,7 @@ limitations under the License.
 terraform {
   required_providers {
     redfish = {
-      version = "1.1.0"
-      source  = "registry.terraform.io/dell/redfish"
+      source = "registry.terraform.io/dell/redfish"
     }
   }
 }
@@ -152,23 +151,50 @@ resource "redfish_storage_volume" "volume" {
     ssl_insecure = each.value.ssl_insecure
   }
 
-  storage_controller_id = "RAID.Integrated.1-1"
-  volume_name           = "TerraformVol"
-  volume_type           = "NonRedundant"
+  storage_controller_id = "RAID.SL.3-1"
+
+  volume_name = "TerraformVol"
+  // This attribute is deprecated, and will be removed in a future release.
+  // Plesae use the raid_type value instead
+  // volume_type           = "Mirrored"
+
+  // Sets the Raid level Options (RAID0, RAID1, RAID5, RAID6, RAID10, RAID50, RAID60)
+  raid_type = "RAID0"
+
   // Name of the physical disk on which virtual disk should get created.
-  drives = ["Solid State Disk 0:0:1"]
+  drives = ["Physical Disk 0:1:0"]
+
   // Flag stating when to create virtual disk either "Immediate" or "OnReset"
+  // For BOSS Drives this should be set to "OnReset" as reboot is needed for the virtual disk to be created
   settings_apply_time = "Immediate"
+
   // Reset parameters to be applied when upgrade is completed
-  reset_type    = "PowerCycle"
+  reset_type = "PowerCycle"
+
   reset_timeout = 100
   // The maximum amount of time to wait for the volume job to be completed
-  volume_job_timeout    = 1200
-  capacity_bytes        = 1073323222
-  optimum_io_size_bytes = 131072
-  read_cache_policy     = "AdaptiveReadAhead"
-  write_cache_policy    = "UnprotectedWriteBack"
-  disk_cache_policy     = "Disabled"
+
+  volume_job_timeout = 1200
+
+  // When creating on volumes on BOSS Controllers or with the encrypt field true this property is invalid. 
+  //capacity_bytes        = 1073323222
+
+  // When creating on volumes on BOSS Controllers or with the encrypt field true this property is invalid. 
+  //optimum_io_size_bytes = 131072
+
+  // Possible values are "Off", "ReadAhead", "AdaptiveReadAhead"
+  read_cache_policy = "Off"
+
+  // When creating on volumes on BOSS Controllers this property should be set to "WriteThrough"
+  // Possible values are "ProtectedWriteBack", "WriteThrough", "UnprotectedWriteBack"
+  write_cache_policy = "WriteThrough"
+
+  // Possible values are "Disabled", "Enabled"
+  disk_cache_policy = "Disabled"
+
+  // Whether or not to encrypt the virtual disk, default to false
+  // Once a virtual disk is set to encrypted status it cannot be changed
+  encrypted = true
 
   lifecycle {
     ignore_changes = [
@@ -189,19 +215,21 @@ After the successful execution of the above resource block, virtual disk would h
 - `drives` (List of String) Drives
 - `storage_controller_id` (String) Storage Controller ID
 - `volume_name` (String) Volume Name
-- `volume_type` (String) Volume Type
 
 ### Optional
 
 - `capacity_bytes` (Number) Capacity Bytes
 - `disk_cache_policy` (String) Disk Cache Policy
+- `encrypted` (Boolean) Encrypt the virtual disk, default is false
 - `optimum_io_size_bytes` (Number) Optimum Io Size Bytes
+- `raid_type` (String) Raid Type, Defaults to RAID0
 - `read_cache_policy` (String) Read Cache Policy
 - `redfish_server` (Block List) List of server BMCs and their respective user credentials (see [below for nested schema](#nestedblock--redfish_server))
 - `reset_timeout` (Number) Reset Timeout
 - `reset_type` (String) Reset Type
 - `settings_apply_time` (String) Settings Apply Time
 - `volume_job_timeout` (Number) Volume Job Timeout
+- `volume_type` (String, Deprecated) Volume Type
 - `write_cache_policy` (String) Write Cache Policy
 
 ### Read-Only

--- a/examples/resources/redfish_storage_volume/provider.tf
+++ b/examples/resources/redfish_storage_volume/provider.tf
@@ -18,8 +18,7 @@ limitations under the License.
 terraform {
   required_providers {
     redfish = {
-      version = "1.1.0"
-      source  = "registry.terraform.io/dell/redfish"
+      source = "registry.terraform.io/dell/redfish"
     }
   }
 }

--- a/examples/resources/redfish_storage_volume/resource.tf
+++ b/examples/resources/redfish_storage_volume/resource.tf
@@ -25,23 +25,50 @@ resource "redfish_storage_volume" "volume" {
     ssl_insecure = each.value.ssl_insecure
   }
 
-  storage_controller_id = "RAID.Integrated.1-1"
-  volume_name           = "TerraformVol"
-  volume_type           = "NonRedundant"
+  storage_controller_id = "RAID.SL.3-1"
+
+  volume_name = "TerraformVol"
+  // This attribute is deprecated, and will be removed in a future release.
+  // Plesae use the raid_type value instead
+  // volume_type           = "Mirrored"
+
+  // Sets the Raid level Options (RAID0, RAID1, RAID5, RAID6, RAID10, RAID50, RAID60)
+  raid_type = "RAID0"
+
   // Name of the physical disk on which virtual disk should get created.
-  drives = ["Solid State Disk 0:0:1"]
+  drives = ["Physical Disk 0:1:0"]
+
   // Flag stating when to create virtual disk either "Immediate" or "OnReset"
+  // For BOSS Drives this should be set to "OnReset" as reboot is needed for the virtual disk to be created
   settings_apply_time = "Immediate"
+
   // Reset parameters to be applied when upgrade is completed
-  reset_type    = "PowerCycle"
+  reset_type = "PowerCycle"
+
   reset_timeout = 100
   // The maximum amount of time to wait for the volume job to be completed
-  volume_job_timeout    = 1200
-  capacity_bytes        = 1073323222
-  optimum_io_size_bytes = 131072
-  read_cache_policy     = "AdaptiveReadAhead"
-  write_cache_policy    = "UnprotectedWriteBack"
-  disk_cache_policy     = "Disabled"
+
+  volume_job_timeout = 1200
+
+  // When creating on volumes on BOSS Controllers or with the encrypt field true this property is invalid. 
+  //capacity_bytes        = 1073323222
+
+  // When creating on volumes on BOSS Controllers or with the encrypt field true this property is invalid. 
+  //optimum_io_size_bytes = 131072
+
+  // Possible values are "Off", "ReadAhead", "AdaptiveReadAhead"
+  read_cache_policy = "Off"
+
+  // When creating on volumes on BOSS Controllers this property should be set to "WriteThrough"
+  // Possible values are "ProtectedWriteBack", "WriteThrough", "UnprotectedWriteBack"
+  write_cache_policy = "WriteThrough"
+
+  // Possible values are "Disabled", "Enabled"
+  disk_cache_policy = "Disabled"
+
+  // Whether or not to encrypt the virtual disk, default to false
+  // Once a virtual disk is set to encrypted status it cannot be changed
+  encrypted = true
 
   lifecycle {
     ignore_changes = [

--- a/redfish/models/storage_volume.go
+++ b/redfish/models/storage_volume.go
@@ -6,6 +6,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 type RedfishStorageVolume struct {
 	CapacityBytes       types.Int64     `tfsdk:"capacity_bytes"`
 	DiskCachePolicy     types.String    `tfsdk:"disk_cache_policy"`
+	RaidType            types.String    `tfsdk:"raid_type"`
 	Drives              types.List      `tfsdk:"drives"`
 	ID                  types.String    `tfsdk:"id"`
 	RedfishServer       []RedfishServer `tfsdk:"redfish_server"`
@@ -19,4 +20,5 @@ type RedfishStorageVolume struct {
 	VolumeName          types.String    `tfsdk:"volume_name"`
 	VolumeType          types.String    `tfsdk:"volume_type"`
 	WriteCachePolicy    types.String    `tfsdk:"write_cache_policy"`
+	Encrypted           types.Bool      `tfsdk:"encrypted"`
 }


### PR DESCRIPTION
##### SUMMARY
- Add Support for RAID6 and RAID60.
- Add Support for Creating Virtual Disks on BOSS Storage Controllers
- Add Support for Encrypted Virtual Disks

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Storage Volume Resource

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):.
```
- Add Support for RAID6 and RAID60.
- Add Support for BOSS Storage Controllers
- Add Support for Encrypted Virtual Disks
```

#### Output from acceptance testing:
```
--- PASS: TestAccRedfishStorageVolume_Encrypted (277.19s)
PASS
ok      terraform-provider-redfish/redfish/provider     280.722s
```
<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
