### PR TITLE
fixed system attributes import

### DIFF
--- a/redfish/provider/resource_redfish_dell_system_attributes.go
+++ b/redfish/provider/resource_redfish_dell_system_attributes.go
@@ -187,10 +187,11 @@ func (*dellSystemAttributesResource) Delete(ctx context.Context, _ resource.Dele
 // ImportState import state for existing DellSystemAttributes
 func (*dellSystemAttributesResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	type creds struct {
-		Username    string `json:"username"`
-		Password    string `json:"password"`
-		Endpoint    string `json:"endpoint"`
-		SslInsecure bool   `json:"ssl_insecure"`
+		Username    string   `json:"username"`
+		Password    string   `json:"password"`
+		Endpoint    string   `json:"endpoint"`
+		SslInsecure bool     `json:"ssl_insecure"`
+		Attributes  []string `json:"attributes"`
 	}
 
 	var c creds
@@ -211,6 +212,17 @@ func (*dellSystemAttributesResource) ImportState(ctx context.Context, req resour
 
 	redfishServer := path.Root("redfish_server")
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, redfishServer, []models.RedfishServer{server})...)
+
+	attributes := path.Root("attributes")
+	if c.Attributes == nil {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attributes, types.MapNull(types.StringType))...)
+		return
+	}
+	readAttributes := make(map[string]attr.Value)
+	for _, k := range c.Attributes {
+		readAttributes[k] = types.StringValue("")
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attributes, types.MapValueMust(types.StringType, readAttributes))...)
 }
 
 func updateRedfishDellSystemAttributes(ctx context.Context, service *gofish.Service, d *models.DellSystemAttributes) diag.Diagnostics {


### PR DESCRIPTION
Issue: Importing system attributes with specific attributes was importing all the attributes instead of the specified ones.

Testing:
```
# terraform import redfish_dell_system_attributes.system '{"username":"root","password":"calvin","endpoint":"https://10.226.197.142","ssl_insecure":true,"attributes":["PCIeSlotLFM.3.MaxLFM"]}'
redfish_dell_system_attributes.system: Importing from ID "{\"username\":\"root\",\"password\":\"calvin\",\"endpoint\":\"https://10.226.197.142\",\"ssl_insecure\":true,\"attributes\":[\"PCIeSlotLFM.3.MaxLFM\"]}"...
redfish_dell_system_attributes.system: Import prepared!
  Prepared redfish_dell_system_attributes for import
redfish_dell_system_attributes.system: Refreshing state... [id=importId]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

```
# cat terraform.tfstate
{
  "version": 4,
  "terraform_version": "1.6.4",
  "serial": 3,
  "lineage": "65da862c-bc02-96ef-bc3a-6ff3f9eff76a",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "redfish_dell_system_attributes",
      "name": "system",
      "provider": "provider[\"registry.terraform.io/dell/redfish\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "attributes": {
              "PCIeSlotLFM.3.MaxLFM": "780"
            },
            "id": "importId",
            "redfish_server": [
              {
                "endpoint": "https://10.226.197.142",
                "password": "calvin",
                "ssl_insecure": true,
                "user": "root"
              }
            ]
          },
          "sensitive_attributes": []
        }
      ]
    }
  ],
  "check_results": null
}
```

