### PR TITLE
Add windows to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
     - freebsd
+    - windows
     - linux
     - darwin
   goarch:
@@ -42,6 +43,6 @@ release:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
-  draft: true
+  # draft: true
 changelog:
   skip: true


### PR DESCRIPTION
Config is copied from https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml#L20
Also, creating draft release is useless as they do not work well with present signing automation. Removed that.

# Testing
```
root@lglap049:~/terraform-provider-redfish# goreleaser build --skip-validate --snapshot
  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=6824ac53a8c194c768c062482b6f65e568b86e8a latest tag=v1.1.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod tidy
  • snapshotting
    • building snapshot...                           version=1.1.0-SNAPSHOT-6824ac5
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/terraform-provider-redfish_freebsd_amd64_v1/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_freebsd_386/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_freebsd_arm_6/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_freebsd_arm64/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_windows_amd64_v1/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5.exe
    • building                                       binary=dist/terraform-provider-redfish_windows_386/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5.exe
    • building                                       binary=dist/terraform-provider-redfish_windows_arm_6/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5.exe
    • building                                       binary=dist/terraform-provider-redfish_windows_arm64/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5.exe
    • building                                       binary=dist/terraform-provider-redfish_linux_amd64_v1/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_linux_386/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_linux_arm_6/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_linux_arm64/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_darwin_amd64_v1/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • building                                       binary=dist/terraform-provider-redfish_darwin_arm64/terraform-provider-redfish_v1.1.0-SNAPSHOT-6824ac5
    • took: 36s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 36s
root@lglap049:~/terraform-provider-redfish#
```
We can see that windows .exe files are getting generated