### PR TITLE
Session based auth

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -234,7 +234,7 @@ linters-settings:
       - name: function-length
         severity: warning
         disabled: false
-        arguments: [70, 0]
+        arguments: [75, 0]
       # https://github.com/mgechev/revive/blob/[main]/RULES_DESCRIPTIONS.md#get-return
       - name: get-return
         severity: warning

--- a/redfish/provider/common.go
+++ b/redfish/provider/common.go
@@ -153,7 +153,7 @@ func getSystemResource(service *gofish.Service) (*redfish.ComputerSystem, error)
 // See https://github.com/stmcginnis/gofish for details. This function returns a Service struct which can then be
 // used to make any required API calls.
 // To-Do: Verify from plan modifier, if required implement wrapper for validation of unknown in redfish_server.
-func NewConfig(pconfig *redfishProvider, rserver *[]models.RedfishServer) (*gofish.Service, error) {
+func NewConfig(pconfig *redfishProvider, rserver *[]models.RedfishServer) (*gofish.APIClient, error) {
 	if len(*rserver) == 0 {
 		return nil, fmt.Errorf("no provider block was found")
 	}
@@ -186,18 +186,18 @@ func NewConfig(pconfig *redfishProvider, rserver *[]models.RedfishServer) (*gofi
 	}
 
 	clientConfig := gofish.ClientConfig{
-		Endpoint:  rserver1.Endpoint.ValueString(),
-		Username:  redfishClientUser,
-		Password:  redfishClientPass,
-		BasicAuth: true,
-		Insecure:  rserver1.SslInsecure.ValueBool(),
+		Endpoint: rserver1.Endpoint.ValueString(),
+		Username: redfishClientUser,
+		Password: redfishClientPass,
+		Insecure: rserver1.SslInsecure.ValueBool(),
 	}
+
 	api, err := gofish.Connect(clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to redfish API: %w", err)
 	}
 	log.Printf("Connection with the redfish endpoint %v was sucessful\n", rserver1.Endpoint.ValueString())
-	return api.Service, nil
+	return api, nil
 }
 
 type powerOperator struct {

--- a/redfish/provider/data_source_redfish_bios.go
+++ b/redfish/provider/data_source_redfish_bios.go
@@ -108,13 +108,14 @@ func (g *BiosDatasource) Read(ctx context.Context, req datasource.ReadRequest, r
 	var plan models.BiosDatasource
 	diags := req.Config.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
-	service, err := NewConfig(g.p, &plan.RedfishServer)
+	api, err := NewConfig(g.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	defer api.Logout()
 	g.ctx = ctx
-	g.service = service
+	g.service = api.Service
 	state, diags := g.readDatasourceRedfishBios(plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/redfish/provider/data_source_redfish_dell_idrac_attributes.go
+++ b/redfish/provider/data_source_redfish_dell_idrac_attributes.go
@@ -104,11 +104,13 @@ func (g *DellIdracAttributesDatasource) Read(ctx context.Context, req datasource
 	if state.ID.IsUnknown() {
 		state.ID = types.StringValue("placeholder")
 	}
-	service, err := NewConfig(g.p, &state.RedfishServer)
+	api, err := NewConfig(g.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	diags = readDatasourceRedfishDellIdracAttributes(service, &state)
 	resp.Diagnostics.Append(diags...)
 	diags = resp.State.Set(ctx, &state)

--- a/redfish/provider/data_source_redfish_firmware_inventory.go
+++ b/redfish/provider/data_source_redfish_firmware_inventory.go
@@ -115,11 +115,13 @@ func (g *FirmwareInventoryDatasource) Read(ctx context.Context, req datasource.R
 	var plan models.FirmwareInventory
 	diags := req.Config.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
-	service, err := NewConfig(g.p, &plan.RedfishServer)
+	api, err := NewConfig(g.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	state, err := readRedfishFirmwareInventory(service)
 	if err != nil {
 		diags.AddError("failed to fetch firmware inventory details", err.Error())

--- a/redfish/provider/data_source_redfish_storage.go
+++ b/redfish/provider/data_source_redfish_storage.go
@@ -112,11 +112,13 @@ func (g *StorageDatasource) Read(ctx context.Context, req datasource.ReadRequest
 	var plan models.StorageDatasource
 	diags := req.Config.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
-	service, err := NewConfig(g.p, &plan.RedfishServer)
+	api, err := NewConfig(g.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	g.ctx = ctx
 	g.service = service
 

--- a/redfish/provider/data_source_redfish_system_boot.go
+++ b/redfish/provider/data_source_redfish_system_boot.go
@@ -19,7 +19,6 @@ package provider
 
 import (
 	"context"
-
 	"terraform-provider-redfish/redfish/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -119,11 +118,13 @@ func (g *SystemBootDatasource) Read(ctx context.Context, req datasource.ReadRequ
 	var plan models.SystemBootDataSource
 	diags := req.Config.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
-	service, err := NewConfig(g.p, &plan.RedfishServer)
+	api, err := NewConfig(g.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	state, diags := readRedfishSystemBoot(service, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/redfish/provider/data_source_redfish_virtual_media.go
+++ b/redfish/provider/data_source_redfish_virtual_media.go
@@ -102,11 +102,13 @@ func (g *DellVirtualMediaDatasource) Read(ctx context.Context, req datasource.Re
 	if state.ID.IsUnknown() {
 		state.ID = types.StringValue("placeholder")
 	}
-	service, err := NewConfig(g.p, &state.RedfishServer)
+	api, err := NewConfig(g.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	diags = readRedfishDellVirtualMediaCollection(service, &state)
 	resp.Diagnostics.Append(diags...)
 	diags = resp.State.Set(ctx, &state)

--- a/redfish/provider/resource_certificate.go
+++ b/redfish/provider/resource_certificate.go
@@ -242,10 +242,12 @@ type CertUtilsParam struct {
 
 func certutils(params CertUtilsParam) (ok bool, summary string, details string) {
 	// Get service
-	service, err := NewConfig(params.pconfig, params.rserver)
+	api, err := NewConfig(params.pconfig, params.rserver)
 	if err != nil {
 		return false, ServiceErrorMsg, err.Error()
 	}
+	service := api.Service
+	defer api.Logout()
 	managers, err := service.Managers()
 	if err != nil {
 		return false, "Couldn't retrieve managers from redfish API: ", err.Error()

--- a/redfish/provider/resource_redfish_bios.go
+++ b/redfish/provider/resource_redfish_bios.go
@@ -169,11 +169,13 @@ func (r *BiosResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	state, diags := r.updateRedfishDellBiosAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -199,11 +201,13 @@ func (r *BiosResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	err = r.readRedfishDellBiosAttributes(service, &state)
 	if err != nil {
@@ -233,11 +237,13 @@ func (r *BiosResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	state, diags := r.updateRedfishDellBiosAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)

--- a/redfish/provider/resource_redfish_boot_order.go
+++ b/redfish/provider/resource_redfish_boot_order.go
@@ -179,11 +179,13 @@ func (r *BootOrderResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = r.bootOperation(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -216,11 +218,13 @@ func (r *BootOrderResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = r.bootOperation(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -256,11 +260,13 @@ func (r *BootOrderResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	system, err := getSystemResource(service)
 	if err != nil {

--- a/redfish/provider/resource_redfish_boot_sources_override.go
+++ b/redfish/provider/resource_redfish_boot_sources_override.go
@@ -221,11 +221,13 @@ func (r *BootSourceOverrideResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = r.bootOperation(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)

--- a/redfish/provider/resource_redfish_dell_lifecycle_controller_attributes.go
+++ b/redfish/provider/resource_redfish_dell_lifecycle_controller_attributes.go
@@ -115,11 +115,13 @@ func (r *dellLCAttributesResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = updateRedfishDellLCAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -144,11 +146,13 @@ func (r *dellLCAttributesResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = readRedfishDellLCAttributes(ctx, service, &state)
 	resp.Diagnostics.Append(diags...)
@@ -176,11 +180,13 @@ func (r *dellLCAttributesResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = updateRedfishDellLCAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -243,11 +249,13 @@ func (r *dellLCAttributesResource) ImportState(ctx context.Context, req resource
 		readAttributes[k] = types.StringValue("")
 	}
 
-	service, d := r.getLCEnv(&srv)
+	api, d := r.getLCEnv(&srv)
 	resp.Diagnostics = append(resp.Diagnostics, d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	managerAttributeRegistry, err := getManagerAttributeRegistry(service)
 	if err != nil {
@@ -271,15 +279,15 @@ func (r *dellLCAttributesResource) ImportState(ctx context.Context, req resource
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attributes, types.MapValueMust(types.StringType, readAttributes))...)
 }
 
-func (r *dellLCAttributesResource) getLCEnv(rserver *[]models.RedfishServer) (*gofish.Service, diag.Diagnostics) {
+func (r *dellLCAttributesResource) getLCEnv(rserver *[]models.RedfishServer) (*gofish.APIClient, diag.Diagnostics) {
 	var d diag.Diagnostics
 	// Get service
-	service, err := NewConfig(r.p, rserver)
+	api, err := NewConfig(r.p, rserver)
 	if err != nil {
 		d.AddError(ServiceErrorMsg, err.Error())
 		return nil, d
 	}
-	return service, nil
+	return api, nil
 }
 
 func updateRedfishDellLCAttributes(ctx context.Context, service *gofish.Service, d *models.DellLCAttributes) diag.Diagnostics {

--- a/redfish/provider/resource_redfish_dell_system_attributes.go
+++ b/redfish/provider/resource_redfish_dell_system_attributes.go
@@ -115,11 +115,13 @@ func (r *dellSystemAttributesResource) Create(ctx context.Context, req resource.
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = updateRedfishDellSystemAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -144,11 +146,13 @@ func (r *dellSystemAttributesResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = readRedfishDellSystemAttributes(ctx, service, &state)
 	resp.Diagnostics.Append(diags...)
@@ -176,11 +180,13 @@ func (r *dellSystemAttributesResource) Update(ctx context.Context, req resource.
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = updateRedfishDellSystemAttributes(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -243,11 +249,13 @@ func (r *dellSystemAttributesResource) ImportState(ctx context.Context, req reso
 		readAttributes[k] = types.StringValue("")
 	}
 
-	service, d := r.getEnv(&srv)
+	api, d := r.getEnv(&srv)
 	resp.Diagnostics = append(resp.Diagnostics, d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	managerAttributeRegistry, err := getManagerAttributeRegistry(service)
 	if err != nil {
@@ -271,15 +279,15 @@ func (r *dellSystemAttributesResource) ImportState(ctx context.Context, req reso
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attributes, types.MapValueMust(types.StringType, readAttributes))...)
 }
 
-func (r *dellSystemAttributesResource) getEnv(rserver *[]models.RedfishServer) (*gofish.Service, diag.Diagnostics) {
+func (r *dellSystemAttributesResource) getEnv(rserver *[]models.RedfishServer) (*gofish.APIClient, diag.Diagnostics) {
 	var d diag.Diagnostics
 	// Get service
-	service, err := NewConfig(r.p, rserver)
+	api, err := NewConfig(r.p, rserver)
 	if err != nil {
 		d.AddError(ServiceErrorMsg, err.Error())
 		return nil, d
 	}
-	return service, nil
+	return api, nil
 }
 
 func updateRedfishDellSystemAttributes(ctx context.Context, service *gofish.Service, d *models.DellSystemAttributes) diag.Diagnostics {

--- a/redfish/provider/resource_redfish_manager_reset.go
+++ b/redfish/provider/resource_redfish_manager_reset.go
@@ -139,11 +139,13 @@ func (r *managerResetResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("Error while getting service", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	// Check iDRAC status
 	checker := ServerStatusChecker{
@@ -226,10 +228,13 @@ func getManagerFromCollection(managers []*redfish.Manager, managerID string) (*r
 }
 
 func getManager(r *managerResetResource, d models.RedfishManagerReset, managerID string) (*redfish.Manager, error) {
-	service, err := NewConfig(r.p, &d.RedfishServer)
+	api, err := NewConfig(r.p, &d.RedfishServer)
 	if err != nil {
 		return nil, err
 	}
+
+	service := api.Service
+	defer api.Logout()
 
 	managers, err := service.Managers()
 	if err != nil {

--- a/redfish/provider/resource_redfish_power.go
+++ b/redfish/provider/resource_redfish_power.go
@@ -152,11 +152,13 @@ func (r *powerResource) Create(ctx context.Context, req resource.CreateRequest, 
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	system, err := getSystemResource(service)
 	if err != nil {
 		resp.Diagnostics.AddError("system error", err.Error())
@@ -197,11 +199,13 @@ func (r *powerResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	system, err := getSystemResource(service)
 	if err != nil {

--- a/redfish/provider/resource_redfish_scp_export.go
+++ b/redfish/provider/resource_redfish_scp_export.go
@@ -459,11 +459,13 @@ func (r *ScpExportResource) Create(ctx context.Context, req resource.CreateReque
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error - config create", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	content, err := scpExportExecutor(ctx, service, plan)
 	if err != nil {

--- a/redfish/provider/resource_redfish_scp_import.go
+++ b/redfish/provider/resource_redfish_scp_import.go
@@ -495,11 +495,13 @@ func (r *ScpImportResource) Create(ctx context.Context, req resource.CreateReque
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	log, err := scpImportExecutor(ctx, service, plan)
 	if err != nil {

--- a/redfish/provider/resource_redfish_simple_update.go
+++ b/redfish/provider/resource_redfish_simple_update.go
@@ -216,11 +216,13 @@ func (r *simpleUpdateResource) Create(ctx context.Context, req resource.CreateRe
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	system, err := getSystemResource(service)
 	if err != nil {
 		resp.Diagnostics.AddError("system error", err.Error())
@@ -253,11 +255,13 @@ func (r *simpleUpdateResource) Read(ctx context.Context, req resource.ReadReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError("service error", err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 	dia, newState := readRedfishSimpleUpdate(service, state)
 	resp.Diagnostics.Append(dia...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)

--- a/redfish/provider/resource_redfish_simple_update_test.go
+++ b/redfish/provider/resource_redfish_simple_update_test.go
@@ -74,7 +74,7 @@ func TestAccRedfishSimpleUpdate_InvalidProto(t *testing.T) {
 					creds,
 					"HTTP",
 					os.Getenv("TF_TESTING_FIRMWARE_IMAGE_INVALID")),
-				ExpectError: regexp.MustCompile("couldn't open FW file to upload - error when opening"),
+				ExpectError: regexp.MustCompile("please check the image path, download failed"),
 			},
 			{
 				Config: testAccRedfishResourceUpdateConfig(

--- a/redfish/provider/resource_redfish_storage_volume.go
+++ b/redfish/provider/resource_redfish_storage_volume.go
@@ -287,11 +287,13 @@ func (r *RedfishStorageVolumeResource) Create(ctx context.Context, req resource.
 		return
 	}
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = createRedfishStorageVolume(ctx, service, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -316,11 +318,13 @@ func (r *RedfishStorageVolumeResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags, cleanup := readRedfishStorageVolume(service, &state)
 	if cleanup {
@@ -362,11 +366,13 @@ func (r *RedfishStorageVolumeResource) Update(ctx context.Context, req resource.
 			"Cannot disable encryption, once a disk is encrypted it cannot be transformed back into an non-encrypted state.")
 		return
 	}
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = updateRedfishStorageVolume(ctx, service, &plan, &state)
 	resp.Diagnostics.Append(diags...)
@@ -391,11 +397,13 @@ func (r *RedfishStorageVolumeResource) Delete(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	diags = deleteRedfishStorageVolume(ctx, service, &state)
 	resp.Diagnostics.Append(diags...)

--- a/redfish/provider/resource_redfish_user_account.go
+++ b/redfish/provider/resource_redfish_user_account.go
@@ -155,11 +155,13 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	tflog.Trace(ctx, "resource_user_account create: updating state finished, saving ...")
 	password := plan.Password.ValueString()
@@ -261,11 +263,13 @@ func (r *UserAccountResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	_, account, err := GetUserAccountFromID(service, state.ID.ValueString())
 	if err != nil {
@@ -310,11 +314,13 @@ func (r *UserAccountResource) Update(ctx context.Context, req resource.UpdateReq
 	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
 	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
 
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	// validate Password
 	err = validatePassword(plan.Password.ValueString())
@@ -382,11 +388,13 @@ func (r *UserAccountResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	_, account, err := GetUserAccountFromID(service, state.ID.ValueString())
 	if err != nil {

--- a/redfish/provider/resource_redfish_user_account_password_test.go
+++ b/redfish/provider/resource_redfish_user_account_password_test.go
@@ -51,7 +51,7 @@ func TestAccRedfishUserPassword_basic(t *testing.T) {
 				%s
 				`,
 					testAccRedfishResourceUserPasswordConfig(creds, "test1", "Test@1234", "Test@1235", "")),
-				ExpectError: regexp.MustCompile("unable to access user data, please check access credentials"),
+				ExpectError: regexp.MustCompile(ServiceErrorMsg),
 			},
 			{
 				Config: fmt.Sprintf(`

--- a/redfish/provider/resource_redfish_virtual_media.go
+++ b/redfish/provider/resource_redfish_virtual_media.go
@@ -165,11 +165,12 @@ func (r *virtualMediaResource) Create(ctx context.Context, req resource.CreateRe
 		TransferProtocolType: redfish.TransferProtocolType(plan.TransferProtocolType.ValueString()),
 		WriteProtected:       plan.WriteProtected.ValueBool(),
 	}
-	env, d := r.getVMEnv(&plan.RedfishServer)
+	api, env, d := r.getVMEnv(&plan.RedfishServer)
 	resp.Diagnostics = append(resp.Diagnostics, d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	defer api.Logout()
 	service, virtualMediaCollection := env.service, env.collection
 
 	if !env.isManager {
@@ -224,34 +225,35 @@ type virtualMediaEnvironment struct {
 	service    *gofish.Service
 }
 
-func (r *virtualMediaResource) getVMEnv(rserver *[]models.RedfishServer) (virtualMediaEnvironment, diag.Diagnostics) {
+func (r *virtualMediaResource) getVMEnv(rserver *[]models.RedfishServer) (*gofish.APIClient, virtualMediaEnvironment, diag.Diagnostics) {
 	var d diag.Diagnostics
 	var env virtualMediaEnvironment
 	// Get service
-	service, err := NewConfig(r.p, rserver)
+	api, err := NewConfig(r.p, rserver)
 	if err != nil {
 		d.AddError(ServiceErrorMsg, err.Error())
-		return env, d
+		return api, env, d
 	}
+	service := api.Service
 	env.service = service
 	// Get Systems details
 	system, err := getSystemResource(service)
 	if err != nil {
 		d.AddError("Error when retrieving systems", err.Error())
-		return env, d
+		return api, env, d
 	}
 	// env.system = system
 	// Get virtual media collection from system
 	virtualMediaCollection, err := system.VirtualMedia()
 	if err != nil {
 		d.AddError("Couldn't retrieve virtual media collection from redfish API", err.Error())
-		return env, d
+		return api, env, d
 	}
 	if len(virtualMediaCollection) != 0 {
 		// This happens in iDRAC 6.x and later
 		env.collection = virtualMediaCollection
 		env.isManager = false
-		return env, d
+		return api, env, d
 	}
 	// This implementation is added to support iDRAC firmware version 5.x. As virtual media can only be accessed through Managers card on 5.x.
 	// Get OOB Manager card - managers[0] will be our oob card
@@ -259,16 +261,16 @@ func (r *virtualMediaResource) getVMEnv(rserver *[]models.RedfishServer) (virtua
 	managers, err := service.Managers()
 	if err != nil {
 		d.AddError("Couldn't retrieve managers from redfish API: ", err.Error())
-		return env, d
+		return api, env, d
 	}
 	// Get virtual media collection from manager
 	virtualMediaCollection, err = managers[0].VirtualMedia()
 	if err != nil {
 		d.AddError("Couldn't retrieve virtual media collection from redfish API: ", err.Error())
-		return env, d
+		return api, env, d
 	}
 	env.collection = virtualMediaCollection
-	return env, d
+	return api, env, d
 }
 
 // Read refreshes the Terraform state with the latest data.
@@ -283,11 +285,13 @@ func (r *virtualMediaResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	// Get service
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	// Get virtual media details
 	virtualMedia, err := redfish.GetVirtualMedia(service.GetClient(), state.VirtualMediaID.ValueString())
@@ -334,11 +338,12 @@ func (r *virtualMediaResource) ImportState(ctx context.Context, req resource.Imp
 
 	creds := []models.RedfishServer{server}
 
-	env, d := r.getVMEnv(&creds)
+	api, env, d := r.getVMEnv(&creds)
 	resp.Diagnostics = append(resp.Diagnostics, d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	defer api.Logout()
 
 	// get virtual media with given ID
 	var media *redfish.VirtualMedia
@@ -390,11 +395,13 @@ func (r *virtualMediaResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// Get service
-	service, err := NewConfig(r.p, &plan.RedfishServer)
+	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	// Validate image extension
 	image := plan.Image.ValueString()
@@ -477,11 +484,13 @@ func (r *virtualMediaResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	// Get service
-	service, err := NewConfig(r.p, &state.RedfishServer)
+	api, err := NewConfig(r.p, &state.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
 		return
 	}
+	service := api.Service
+	defer api.Logout()
 
 	// Get virtual media details
 	virtualMedia, err := redfish.GetVirtualMedia(service.GetClient(), state.VirtualMediaID.ValueString())


### PR DESCRIPTION
```

open redfish_test.env: no such file or directory
=== RUN   TestAccRedfishBiosDataSource_basic
--- PASS: TestAccRedfishBiosDataSource_basic (13.00s)
=== RUN   TestAccRedfishiDRACDataSource_fetch
--- PASS: TestAccRedfishiDRACDataSource_fetch (10.47s)
=== RUN   TestAccRedfishFirmwareDataSource_basic
--- PASS: TestAccRedfishFirmwareDataSource_basic (86.05s)
=== RUN   TestAccRedfishStorageDataSource_fetch
--- PASS: TestAccRedfishStorageDataSource_fetch (58.88s)
=== RUN   TestAccRedfishSystemBoot_fetch
--- PASS: TestAccRedfishSystemBoot_fetch (14.17s)
=== RUN   TestAccRedfishSystemBoot_fetchInvalidID
--- PASS: TestAccRedfishSystemBoot_fetchInvalidID (1.56s)
=== RUN   TestAccRedfishVirtualMedia_fetch
--- PASS: TestAccRedfishVirtualMedia_fetch (11.37s)
=== RUN   TestAccRedfishCertificate_basic
    resource_certificate_test.go:33: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Read local file data source error
        
          with data.local_file.cert,
          on terraform_plugin_test.tf line 13, in data "local_file" "cert":
          13: 		data "local_file" "cert" {
        
        The file at given path cannot be read.
        
        +Original Error: open : no such file or directory
--- FAIL: TestAccRedfishCertificate_basic (1.90s)
=== RUN   TestAccRedfishBios_basic
--- PASS: TestAccRedfishBios_basic (883.97s)
=== RUN   TestAccRedfishBios_InvalidSettings
--- PASS: TestAccRedfishBios_InvalidSettings (0.16s)
=== RUN   TestAccRedfishBios_InvalidAttributes
--- PASS: TestAccRedfishBios_InvalidAttributes (0.15s)
=== RUN   TestAccRedfishBios_Import
--- PASS: TestAccRedfishBios_Import (1.71s)
=== RUN   TestAccRedfishBootOrder_basic
--- PASS: TestAccRedfishBootOrder_basic (20.13s)
--- FAIL: TestAccRedfishBootOrder_basic (1.68s)
=== RUN   TestAccRedfishBootOrderOptions_basic
--- PASS: TestAccRedfishBootOrderOptions_basic (952.10s)
=== RUN   TestAccRedfishBootSourceOverride_basic
--- PASS: TestAccRedfishBootSourceOverride_basic (537.60s)
=== RUN   TestAccRedfishBootSourceOverride_updated
--- PASS: TestAccRedfishBootSourceOverride_updated (480.31s)
=== RUN   TestAccRedfishIDRACAttributesBasic
--- PASS: TestAccRedfishIDRACAttributesBasic (28.25s)
=== RUN   TestAccRedfishIDRACAttributesInvalidAttribute
--- PASS: TestAccRedfishIDRACAttributesInvalidAttribute (3.76s)
=== RUN   TestAccRedfishIDRACAttributeImport
--- PASS: TestAccRedfishIDRACAttributeImport (4.41s)
=== RUN   TestAccRedfishIDRACAttributeImportByFilter
--- PASS: TestAccRedfishIDRACAttributeImportByFilter (6.78s)
=== RUN   TestAccRedfishLCAttributesBasic
--- PASS: TestAccRedfishLCAttributesBasic (14.51s)
=== RUN   TestAccRedfishLCAttributesInvalidAttribute
--- PASS: TestAccRedfishLCAttributesInvalidAttribute (4.13s)
=== RUN   TestAccRedfishLCAttributesUpdate
--- PASS: TestAccRedfishLCAttributesUpdate (19.21s)
=== RUN   TestAccRedfishLCAttributeImport
--- PASS: TestAccRedfishLCAttributeImport (2.15s)
=== RUN   TestAccRedfishSystemAttributesBasic
--- PASS: TestAccRedfishSystemAttributesBasic (9.57s)
=== RUN   TestAccRedfishSystemAttributesInvalidAttribute
--- PASS: TestAccRedfishSystemAttributesInvalidAttribute (4.18s)
=== RUN   TestAccRedfishSystemAttributesUpdate
--- PASS: TestAccRedfishSystemAttributesUpdate (26.20s)
=== RUN   TestAccRedfishSystemAttributesImport
--- PASS: TestAccRedfishSystemAttributesImport (2.79s)
=== RUN   TestAccRedfishIdracFirmwareUpdateResource
    resource_redfish_idrac_firmware_update_test.go:30: Step 2/2 error: Error running apply: exit status 1
        
        Error: Check repository Updates job error
        
          with redfish_idrac_firmware_update.update2,
          on terraform_plugin_test.tf line 3, in resource "redfish_idrac_firmware_update" "update2":
           3: 	resource "redfish_idrac_firmware_update" "update2" {
        
        The download protocol specified is not supported.
--- FAIL: TestAccRedfishIdracFirmwareUpdateResource (45.84s)
=== RUN   TestAccRedfishIdracFirmwareUpdateResourceFail
--- PASS: TestAccRedfishIdracFirmwareUpdateResourceFail (0.20s)
=== RUN   TestAccRedfishManagerReset_Invalid_ResetType_Negative
--- PASS: TestAccRedfishManagerReset_Invalid_ResetType_Negative (0.16s)
=== RUN   TestAccRedfishManagerReset_Invalid_ManagerID_Negative
    resource_redfish_manager_reset_test.go:44: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1
        
        Error: Error while retrieving manager from redfish API
        
          with redfish_manager_reset.manager_reset,
          on terraform_plugin_test.tf line 3, in resource "redfish_manager_reset" "manager_reset":
           3: 	resource "redfish_manager_reset" "manager_reset" {
        
        invalid Manager ID provided
--- FAIL: TestAccRedfishManagerReset_Invalid_ManagerID_Negative (2.02s)
=== RUN   TestAccRedfishManagerReset_Update_Negative
    resource_redfish_manager_reset_test.go:58: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error resetting manager
        
          with redfish_manager_reset.manager_reset,
          on terraform_plugin_test.tf line 3, in resource "redfish_manager_reset" "manager_reset":
           3: 	resource "redfish_manager_reset" "manager_reset" {
        
        401: {
            "error": {
                "code": "Base.1.8.GeneralError",
                "message": "A general error has occurred. See ExtendedInfo for more information.",
                "@Message.ExtendedInfo": [
                {
                    "@odata.type": "#Message.v1_1_0.Message",
                    "MessageId": "Base.1.8.AccessDenied",
                    "Message": "The authentication credentials included with this request are missing or invalid.",
        	    "MessageArgs": [],
        	    "MessageArgs@odata.count": 0,
        	    "RelatedProperties":[],
        	    "RelatedProperties@odata.count": 0,
        	    "Severity": "Critical",
        	    "Resolution": "Attempt to ensure that the URI is correct and that the
        service has the appropriate credentials."
                }
                ]
            }
        }
        
--- FAIL: TestAccRedfishManagerReset_Update_Negative (1.87s)
=== RUN   TestAccRedfishManagerReset_Create
    resource_redfish_manager_reset_test.go:78: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error resetting manager
        
          with redfish_manager_reset.manager_reset,
          on terraform_plugin_test.tf line 3, in resource "redfish_manager_reset" "manager_reset":
           3: 	resource "redfish_manager_reset" "manager_reset" {
        
        401: {
            "error": {
                "code": "Base.1.8.GeneralError",
                "message": "A general error has occurred. See ExtendedInfo for more information.",
                "@Message.ExtendedInfo": [
                {
                    "@odata.type": "#Message.v1_1_0.Message",
                    "MessageId": "Base.1.8.AccessDenied",
                    "Message": "The authentication credentials included with this request are missing or invalid.",
        	    "MessageArgs": [],
        	    "MessageArgs@odata.count": 0,
        	    "RelatedProperties":[],
        	    "RelatedProperties@odata.count": 0,
        	    "Severity": "Critical",
        	    "Resolution": "Attempt to ensure that the URI is correct and that the
        service has the appropriate credentials."
                }
                ]
            }
        }
        
--- FAIL: TestAccRedfishManagerReset_Create (1.85s)
=== RUN   TestAccRedfishPowerT1
    resource_redfish_power_test.go:31: Step 6/9 error: Check failed: Check 1/1 error: redfish_power.system_power: Attribute 'power_state' expected "Reset_On", got "Off"
--- FAIL: TestAccRedfishPowerT1 (266.00s)
=== RUN   TestAccRedfishPower_Invalid
--- PASS: TestAccRedfishPower_Invalid (0.16s)
=== RUN   TestAccRedfishSCP
--- PASS: TestAccRedfishSCP (82.15s)
=== RUN   TestAccRedfishSCPInvalid
--- PASS: TestAccRedfishSCPInvalid (0.54s)
=== RUN   TestAccRedfishSimpleUpdate_basic
--- PASS: TestAccRedfishSimpleUpdate_basic (397.22s)
=== RUN   TestAccRedfishSimpleUpdate_InvalidProto
--- PASS: TestAccRedfishSimpleUpdate_InvalidProto (30.05s)
=== RUN   TestAccRedfishStorageDataSource_fetch
--- PASS: TestAccRedfishStorageDataSource_fetch (73.44s)
=== RUN   TestAccRedfishStorageVolume_InvalidController
--- PASS: TestAccRedfishStorageVolume_InvalidController (2.62s)
=== RUN   TestAccRedfishStorageVolume_InvalidDrive
--- PASS: TestAccRedfishStorageVolume_InvalidDrive (3.41s)
=== RUN   TestAccRedfishStorageVolume_InvalidVolumeType
--- PASS: TestAccRedfishStorageVolume_InvalidVolumeType (3.55s)
=== RUN   TestAccRedfishStorageVolumeUpdate_basic
--- PASS: TestAccRedfishStorageVolumeUpdate_basic (425.92s)
=== RUN   TestAccRedfishStorageVolumeCreate_basic
--- PASS: TestAccRedfishStorageVolumeCreate_basic (282.54s)
=== RUN   TestAccRedfishStorageVolume_basic
--- PASS: TestAccRedfishStorageVolume_basic (271.09s)
=== RUN   TestAccRedfishStorageVolume_OnReset
--- PASS: TestAccRedfishStorageVolume_OnReset (462.84s)
=== RUN   TestAccRedfishUserPassword_basic
--- PASS: TestAccRedfishUserPassword_basic (44.67s)
=== RUN   TestAccRedfishUser_basic
--- PASS: TestAccRedfishUser_basic (50.82s)
=== RUN   TestAccRedfishUserInvalid_basic
--- PASS: TestAccRedfishUserInvalid_basic (0.16s)
=== RUN   TestAccRedfishUserExisting_basic
--- PASS: TestAccRedfishUserExisting_basic (9.30s)
=== RUN   TestAccRedfishUserUpdateInvalid_basic
--- PASS: TestAccRedfishUserUpdateInvalid_basic (44.96s)
=== RUN   TestAccRedfishUserUpdateInvalidId_basic
--- PASS: TestAccRedfishUserUpdateInvalidId_basic (8.81s)
=== RUN   TestAccRedfishUserUpdateId_basic
--- PASS: TestAccRedfishUserUpdateId_basic (41.64s)
=== RUN   TestAccRedfishUserUpdateUser_basic
--- PASS: TestAccRedfishUserUpdateUser_basic (63.71s)
=== RUN   TestAccRedfishUserImportUser_basic
--- PASS: TestAccRedfishUserImportUser_basic (6.27s)
=== RUN   TestAccRedfishUserImportUser_invalid
--- PASS: TestAccRedfishUserImportUser_invalid (6.44s)
=== RUN   TestAccRedfishUserValidation_basic
--- PASS: TestAccRedfishUserValidation_basic (40.94s)
=== RUN   TestAccRedfishVirtualMedia_basic
--- PASS: TestAccRedfishVirtualMedia_basic (16.19s)
=== RUN   TestAccRedfishVirtualMedia_InvalidImage_Negative
--- PASS: TestAccRedfishVirtualMedia_InvalidImage_Negative (0.38s)
=== RUN   TestAccRedfishVirtualMedia_InvalidTransferMethod_Negative
--- PASS: TestAccRedfishVirtualMedia_InvalidTransferMethod_Negative (0.42s)
=== RUN   TestAccRedfishVirtualMedia_InvalidTransferProtocol_Negative
--- PASS: TestAccRedfishVirtualMedia_InvalidTransferProtocol_Negative (3.67s)
=== RUN   TestAccRedfishVirtualMediaNoMediaNegative_basic
--- PASS: TestAccRedfishVirtualMediaNoMediaNegative_basic (11.81s)
=== RUN   TestAccRedfishVirtualMediaServer2_basic
--- PASS: TestAccRedfishVirtualMediaServer2_basic (10.35s)
=== RUN   TestAccRedfishVirtualMediaServer2_InvalidTransferProtocol_Negative
--- PASS: TestAccRedfishVirtualMediaServer2_InvalidTransferProtocol_Negative (2.91s)
=== RUN   TestAccRedfishVirtualMediaServer2Update_InvalidTransferProtocol_Negative
--- PASS: TestAccRedfishVirtualMediaServer2Update_InvalidTransferProtocol_Negative (15.32s)
=== RUN   TestAccRedfishVirtualMediaUpdate_basic
--- PASS: TestAccRedfishVirtualMediaUpdate_basic (22.66s)
=== RUN   TestAccRedfishVirtualMediaUpdate_InvalidImage_Negative
--- PASS: TestAccRedfishVirtualMediaUpdate_InvalidImage_Negative (10.37s)
=== RUN   TestAccRedfishVirtualMediaUpdate_InvalidTransferMethod_Negative
--- PASS: TestAccRedfishVirtualMediaUpdate_InvalidTransferMethod_Negative (10.18s)
FAIL
coverage: 70.3% of statements
FAIL	terraform-provider-redfish/redfish/provider	4449.596s
FAIL


All test cases passed except manager reset and certificate which will be taken up as a part of phase 2 development
```