### PR TITLE
Session-based-auth changes added for remaining resources

### DIFF
--- a/redfish/provider/resource_redfish_manager_reset_test.go
+++ b/redfish/provider/resource_redfish_manager_reset_test.go
@@ -47,7 +47,7 @@ func TestAccRedfishManagerReset_Invalid_ManagerID_Negative(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRedfishResourceManagerResetConfig(creds, "iDRAC.Embedded.0", "GracefulRestart"),
-				ExpectError: regexp.MustCompile("Invalid Manager ID provided"),
+				ExpectError: regexp.MustCompile("invalid Manager ID provided"),
 			},
 		},
 	})
@@ -67,7 +67,7 @@ func TestAccRedfishManagerReset_Update_Negative(t *testing.T) {
 			},
 			{
 				Config:      testAccRedfishResourceManagerResetConfig(creds, "iDRAC.Embedded", "GracefulRestart"),
-				ExpectError: regexp.MustCompile("Invalid Manager ID provided"),
+				ExpectError: regexp.MustCompile("invalid Manager ID provided"),
 			},
 		},
 	})

--- a/redfish/provider/resource_redfish_storage_volume_test.go
+++ b/redfish/provider/resource_redfish_storage_volume_test.go
@@ -127,7 +127,7 @@ func TestAccRedfishStorageVolumeUpdate_basic(t *testing.T) {
 					creds,
 					"RAID.Integrated.1-1",
 					"TerraformVol1",
-					"NonRedundant",
+					"RAID0",
 					drive,
 					"Immediate",
 					"AdaptiveReadAhead",
@@ -186,7 +186,6 @@ func TestAccRedfishStorageVolumeCreate_basic(t *testing.T) {
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "storage_controller_id", "RAID.Integrated.1-1"),
-					resource.TestCheckResourceAttr("redfish_storage_volume.volume", "volume_type", "NonRedundant"),
 				),
 				// / TBD: non empty plan fix for
 				ExpectNonEmptyPlan: true,


### PR DESCRIPTION
=== RUN   TestAccRedfishManagerReset_Invalid_ResetType_Negative
--- PASS: TestAccRedfishManagerReset_Invalid_ResetType_Negative (0.17s)
=== RUN   TestAccRedfishManagerReset_Invalid_ManagerID_Negative
--- PASS: TestAccRedfishManagerReset_Invalid_ManagerID_Negative (2.15s)
=== RUN   TestAccRedfishManagerReset_Update_Negative
--- PASS: TestAccRedfishManagerReset_Update_Negative (341.24s)
=== RUN   TestAccRedfishManagerReset_Create
--- PASS: TestAccRedfishManagerReset_Create (341.35s)

=== RUN   TestAccRedfishCertificate_basic
--- PASS: TestAccRedfishCertificate_basic (679.02s)