### PR TITLE
Acceptance tests fixed

### DIFF
--- a/redfish/provider/common.go
+++ b/redfish/provider/common.go
@@ -269,9 +269,8 @@ func (p powerOperator) PowerOperation(resetType string, maximumWaitTime int64, c
 		// If someone asks for a reset while the server is off, change the reset type to on instead
 		if system.PowerState == powerOFF {
 			resetType = "On"
-		} else {
-			targetPowerState = powerON
 		}
+		targetPowerState = powerON
 	}
 
 	if resetType == "PushPowerButton" {

--- a/redfish/provider/data_source_redfish_system_boot_test.go
+++ b/redfish/provider/data_source_redfish_system_boot_test.go
@@ -50,7 +50,7 @@ func TestAccRedfishSystemBoot_fetchInvalidID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRedfishDatasourceSystemBootConfig(creds, "invalid-id"),
-				ExpectError: regexp.MustCompile("Could not find a ComputerSystem"),
+				ExpectError: regexp.MustCompile("Error fetching computer system"),
 			},
 		},
 	})

--- a/redfish/provider/resource_redfish_boot_order_test.go
+++ b/redfish/provider/resource_redfish_boot_order_test.go
@@ -32,7 +32,7 @@ func TestAccRedfishBootOrder_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRedfishResourceBootOrder(creds, `["Boot0003","Boot0004","Boot0005"]`),
+				Config: testAccRedfishResourceBootOrder(creds, os.Getenv("TF_TESTING_BOOT_ORDER")),
 			},
 			{
 				ResourceName:  "redfish_boot_order.boot",

--- a/redfish/provider/resource_redfish_boot_sources_override_test.go
+++ b/redfish/provider/resource_redfish_boot_sources_override_test.go
@@ -20,6 +20,7 @@ package provider
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -46,13 +47,17 @@ func TestAccRedfishBootSourceOverride_updated(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRedfishResourceBootSourceUEFIconfig(creds),
+
+				Config: testAccRedfishResourceBootSourceResetType(creds),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("redfish_boot_source_override.boot", "boot_source_override_mode", "UEFI"),
 				),
 			},
 			{
-				Config: testAccRedfishResourceBootSourceResetType(creds),
+				PreConfig: func() {
+					time.Sleep(120 * time.Second)
+				},
+				Config: testAccRedfishResourceBootSourceUEFIconfig(creds),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("redfish_boot_source_override.boot", "boot_source_override_mode", "UEFI"),
 				),

--- a/redfish/provider/resource_redfish_storage_volume_test.go
+++ b/redfish/provider/resource_redfish_storage_volume_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -69,6 +70,9 @@ func TestAccRedfishStorageVolume_InvalidDrive(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					time.Sleep(180 * time.Second)
+				},
 				Config: testAccRedfishResourceStorageVolumeConfig(
 					creds,
 					"RAID.Integrated.1-1",


### PR DESCRIPTION
```
open redfish_test.env: no such file or directory
=== RUN   TestAccRedfishBiosDataSource_basic
--- PASS: TestAccRedfishBiosDataSource_basic (12.44s)
=== RUN   TestAccRedfishiDRACDataSource_fetch
--- PASS: TestAccRedfishiDRACDataSource_fetch (11.50s)
=== RUN   TestAccRedfishFirmwareDataSource_basic
--- PASS: TestAccRedfishFirmwareDataSource_basic (77.46s)
=== RUN   TestAccRedfishNICDataSource_fetch
--- PASS: TestAccRedfishNICDataSource_fetch (177.66s)
=== RUN   TestAccRedfishStorageDataSource_fetch
--- PASS: TestAccRedfishStorageDataSource_fetch (56.87s)
=== RUN   TestAccRedfishSystemBoot_fetch
--- PASS: TestAccRedfishSystemBoot_fetch (24.47s)
=== RUN   TestAccRedfishSystemBoot_fetchInvalidID
--- PASS: TestAccRedfishSystemBoot_fetchInvalidID (1.41s)
=== RUN   TestAccRedfishVirtualMedia_fetch
--- PASS: TestAccRedfishVirtualMedia_fetch (11.46s)
=== RUN   TestAccRedfishCertificate_basic
--- PASS: TestAccRedfishCertificate_basic (680.07s)
=== RUN   TestAccRedfishBios_basic
--- PASS: TestAccRedfishBios_basic (995.58s)
=== RUN   TestAccRedfishBios_InvalidSettings
--- PASS: TestAccRedfishBios_InvalidSettings (0.16s)
=== RUN   TestAccRedfishBios_InvalidAttributes
--- PASS: TestAccRedfishBios_InvalidAttributes (0.17s)
=== RUN   TestAccRedfishBios_Import
--- PASS: TestAccRedfishBios_Import (2.52s)
=== RUN   TestAccRedfishBios_ImportSystemID
--- PASS: TestAccRedfishBios_ImportSystemID (2.55s)
=== RUN   TestAccRedfishBootOrder_basic
--- PASS: TestAccRedfishBootOrder_basic (9.66s)
=== RUN   TestAccRedfishBootOrderOptions_basic
--- PASS: TestAccRedfishBootOrderOptions_basic (1113.00s)
=== RUN   TestAccRedfishBootSourceOverride_basic
--- PASS: TestAccRedfishBootSourceOverride_basic (497.79s)
=== RUN   TestAccRedfishBootSourceOverride_updated
--- PASS: TestAccRedfishBootSourceOverride_updated (528.52s)
=== RUN   TestAccRedfishIDRACAttributesBasic
--- PASS: TestAccRedfishIDRACAttributesBasic (21.99s)
=== RUN   TestAccRedfishIDRACAttributesInvalidAttribute
--- PASS: TestAccRedfishIDRACAttributesInvalidAttribute (3.91s)
=== RUN   TestAccRedfishIDRACAttributeImport
--- PASS: TestAccRedfishIDRACAttributeImport (3.09s)
=== RUN   TestAccRedfishIDRACAttributeImportByFilter
--- PASS: TestAccRedfishIDRACAttributeImportByFilter (6.24s)
=== RUN   TestAccRedfishLCAttributesBasic
--- PASS: TestAccRedfishLCAttributesBasic (17.22s)
=== RUN   TestAccRedfishLCAttributesInvalidAttribute
--- PASS: TestAccRedfishLCAttributesInvalidAttribute (4.23s)
=== RUN   TestAccRedfishLCAttributesUpdate
--- PASS: TestAccRedfishLCAttributesUpdate (19.69s)
=== RUN   TestAccRedfishLCAttributeImport
--- PASS: TestAccRedfishLCAttributeImport (2.20s)
=== RUN   TestAccRedfishSystemAttributesBasic
--- PASS: TestAccRedfishSystemAttributesBasic (9.41s)
=== RUN   TestAccRedfishSystemAttributesInvalidAttribute
--- PASS: TestAccRedfishSystemAttributesInvalidAttribute (5.02s)
=== RUN   TestAccRedfishSystemAttributesUpdate
--- PASS: TestAccRedfishSystemAttributesUpdate (19.12s)
=== RUN   TestAccRedfishSystemAttributesImport
--- PASS: TestAccRedfishSystemAttributesImport (2.37s)
=== RUN   TestAccRedfishIdracFirmwareUpdateResource
--- PASS: TestAccRedfishIdracFirmwareUpdateResource (38.18s)
=== RUN   TestAccRedfishIdracFirmwareUpdateResourceFail
--- PASS: TestAccRedfishIdracFirmwareUpdateResourceFail (0.23s)
=== RUN   TestAccRedfishManagerReset_Invalid_ResetType_Negative
--- PASS: TestAccRedfishManagerReset_Invalid_ResetType_Negative (0.19s)
=== RUN   TestAccRedfishManagerReset_Invalid_ManagerID_Negative
--- PASS: TestAccRedfishManagerReset_Invalid_ManagerID_Negative (2.09s)
=== RUN   TestAccRedfishManagerReset_Update_Negative
--- PASS: TestAccRedfishManagerReset_Update_Negative (342.43s)
=== RUN   TestAccRedfishManagerReset_Create
--- PASS: TestAccRedfishManagerReset_Create (337.20s)
=== RUN   TestAccRedfishNICAttributesBasic
--- PASS: TestAccRedfishNICAttributesBasic (1234.44s)
=== RUN   TestAccRedfishNICAttributesImport
--- PASS: TestAccRedfishNICAttributesImport (4.84s)
=== RUN   TestAccRedfishPowerT1
--- PASS: TestAccRedfishPowerT1 (216.69s)
=== RUN   TestAccRedfishPower_Invalid
--- PASS: TestAccRedfishPower_Invalid (0.17s)
=== RUN   TestAccRedfishSCP
--- PASS: TestAccRedfishSCP (74.04s)
=== RUN   TestAccRedfishSCPInvalid
--- PASS: TestAccRedfishSCPInvalid (0.58s)
=== RUN   TestAccRedfishSimpleUpdate_basic
--- PASS: TestAccRedfishSimpleUpdate_basic (519.38s)
=== RUN   TestAccRedfishSimpleUpdate_InvalidProto
--- PASS: TestAccRedfishSimpleUpdate_InvalidProto (29.97s)
=== RUN   TestAccRedfishStorageVolume_InvalidController
--- PASS: TestAccRedfishStorageVolume_InvalidController (2.80s)
=== RUN   TestAccRedfishStorageVolume_InvalidDrive
--- PASS: TestAccRedfishStorageVolume_InvalidDrive (184.83s)
=== RUN   TestAccRedfishStorageVolume_InvalidVolumeType
--- PASS: TestAccRedfishStorageVolume_InvalidVolumeType (3.76s)
=== RUN   TestAccRedfishStorageVolumeUpdate_basic
--- PASS: TestAccRedfishStorageVolumeUpdate_basic (441.04s)
=== RUN   TestAccRedfishStorageVolumeCreate_basic
--- PASS: TestAccRedfishStorageVolumeCreate_basic (277.10s)
=== RUN   TestAccRedfishStorageVolume_basic
--- PASS: TestAccRedfishStorageVolume_basic (279.13s)
=== RUN   TestAccRedfishStorageVolume_OnReset
--- PASS: TestAccRedfishStorageVolume_OnReset (443.18s)
=== RUN   TestAccRedfishUserPassword_basic
--- PASS: TestAccRedfishUserPassword_basic (48.33s)
=== RUN   TestAccRedfishUser_basic
--- PASS: TestAccRedfishUser_basic (49.23s)
=== RUN   TestAccRedfishUserInvalid_basic
--- PASS: TestAccRedfishUserInvalid_basic (0.16s)
=== RUN   TestAccRedfishUserExisting_basic
--- PASS: TestAccRedfishUserExisting_basic (5.44s)
=== RUN   TestAccRedfishUserUpdateInvalid_basic
--- PASS: TestAccRedfishUserUpdateInvalid_basic (34.88s)
=== RUN   TestAccRedfishUserUpdateInvalidId_basic
--- PASS: TestAccRedfishUserUpdateInvalidId_basic (6.29s)
=== RUN   TestAccRedfishUserUpdateId_basic
--- PASS: TestAccRedfishUserUpdateId_basic (43.31s)
=== RUN   TestAccRedfishUserUpdateUser_basic
--- PASS: TestAccRedfishUserUpdateUser_basic (65.20s)
=== RUN   TestAccRedfishUserImportUser_basic
--- PASS: TestAccRedfishUserImportUser_basic (7.20s)
=== RUN   TestAccRedfishUserImportUser_invalid
--- PASS: TestAccRedfishUserImportUser_invalid (6.03s)
=== RUN   TestAccRedfishUserValidation_basic
--- PASS: TestAccRedfishUserValidation_basic (37.40s)
=== RUN   TestAccRedfishVirtualMedia_basic
--- PASS: TestAccRedfishVirtualMedia_basic (15.67s)
=== RUN   TestAccRedfishVirtualMedia_InvalidImage_Negative
--- PASS: TestAccRedfishVirtualMedia_InvalidImage_Negative (0.41s)
=== RUN   TestAccRedfishVirtualMedia_InvalidTransferMethod_Negative
--- PASS: TestAccRedfishVirtualMedia_InvalidTransferMethod_Negative (0.48s)
=== RUN   TestAccRedfishVirtualMedia_InvalidTransferProtocol_Negative
--- PASS: TestAccRedfishVirtualMedia_InvalidTransferProtocol_Negative (2.90s)
=== RUN   TestAccRedfishVirtualMediaNoMediaNegative_basic
--- PASS: TestAccRedfishVirtualMediaNoMediaNegative_basic (10.70s)
=== RUN   TestAccRedfishVirtualMediaServer2_basic
--- PASS: TestAccRedfishVirtualMediaServer2_basic (10.36s)
=== RUN   TestAccRedfishVirtualMediaServer2_InvalidTransferProtocol_Negative
--- PASS: TestAccRedfishVirtualMediaServer2_InvalidTransferProtocol_Negative (2.71s)
=== RUN   TestAccRedfishVirtualMediaServer2Update_InvalidTransferProtocol_Negative
--- PASS: TestAccRedfishVirtualMediaServer2Update_InvalidTransferProtocol_Negative (17.06s)
=== RUN   TestAccRedfishVirtualMediaUpdate_basic
--- PASS: TestAccRedfishVirtualMediaUpdate_basic (20.81s)
=== RUN   TestAccRedfishVirtualMediaUpdate_InvalidImage_Negative
--- PASS: TestAccRedfishVirtualMediaUpdate_InvalidImage_Negative (10.16s)
=== RUN   TestAccRedfishVirtualMediaUpdate_InvalidTransferMethod_Negative
--- PASS: TestAccRedfishVirtualMediaUpdate_InvalidTransferMethod_Negative (11.07s)
PASS
coverage: 77.0% of statements
ok  	terraform-provider-redfish/redfish/provider	9155.935s	coverage: 77.0% of statements

```