### PR TITLE
Add AT to increase NIC coverage.

### DIFF
--- a/redfish/provider/provider_test.go
+++ b/redfish/provider/provider_test.go
@@ -40,11 +40,13 @@ var (
 // // TestingServerCredentials Struct used to store the credentials we pass for testing. This allows us to pass testing
 // // credentials via environment variables instead of having them hard coded
 type TestingServerCredentials struct {
-	Username  string
-	Password  string
-	Endpoint  string
-	Endpoint2 string
-	Insecure  bool
+	Username    string
+	Password    string
+	PasswordNIC string
+	Endpoint    string
+	Endpoint2   string
+	EndpointNIC string
+	Insecure    bool
 }
 
 func init() {
@@ -59,13 +61,20 @@ func init() {
 	}
 
 	creds = TestingServerCredentials{
-		Username:  os.Getenv("TF_TESTING_USERNAME"),
-		Password:  os.Getenv("TF_TESTING_PASSWORD"),
-		Endpoint:  os.Getenv("TF_TESTING_ENDPOINT"),
-		Endpoint2: os.Getenv("TF_TESTING_ENDPOINT2"),
-		Insecure:  false,
+		Username:    os.Getenv("TF_TESTING_USERNAME"),
+		Password:    os.Getenv("TF_TESTING_PASSWORD"),
+		Endpoint:    os.Getenv("TF_TESTING_ENDPOINT"),
+		Endpoint2:   os.Getenv("TF_TESTING_ENDPOINT2"),
+		EndpointNIC: os.Getenv("TF_TESTING_ENDPOINT_NIC"),
+		PasswordNIC: os.Getenv("TF_TESTING_PASSWORD_NIC"),
+		Insecure:    false,
 	}
-
+	if creds.EndpointNIC == "" {
+		creds.EndpointNIC = creds.Endpoint
+	}
+	if creds.PasswordNIC == "" {
+		creds.PasswordNIC = creds.Password
+	}
 	// virtual media environment variable
 	image64Boot = os.Getenv("TF_TESTING_VIRTUAL_MEDIA_IMAGE_PATH_64Boot")
 	imageEfiBoot = os.Getenv("TF_TESTING_VIRTUAL_MEDIA_IMAGE_PATH_EfiBoot")


### PR DESCRIPTION
<!--
Copyright (c) 2020-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
Add test cases to increase test coverage for nic resource.


##### COMPONENT NAME
Resource: redfish_network_adapter


#### Output from acceptance testing:
redfish_network_adapter feature has four files:` resource_redfish_nic.go , resource_redfish_nic_helper.go, resource_redfish_nic_schema.go, resource_redfish_nic_schema_helper.go.`
If these four files are considered as a whole to calculate coverage,  the test coverage for the resource is ~85%.

![image](https://github.com/user-attachments/assets/db7bf689-b4cc-40df-9fd2-cc61b81aa272)

![image](https://github.com/user-attachments/assets/479d6f58-905c-43bd-8fb3-69fd72af1e85)

<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
