### PR TITLE
Removal of resource_id in System Boot datasource

### DIFF
--- a/docs/data-sources/system_boot.md
+++ b/docs/data-sources/system_boot.md
@@ -150,9 +150,9 @@ data "redfish_system_boot" "system_boot" {
     ssl_insecure = each.value.ssl_insecure
   }
 
-  // resource_id is an optional argument. By default, the data source uses
+  // system_id is an optional argument. By default, the data source uses
   // the first ComputerSystem resource present in the ComputerSystem collection
-  resource_id = "System.Embedded.1"
+  system_id = "System.Embedded.1"
 }
 
 output "system_boot" {
@@ -167,7 +167,6 @@ output "system_boot" {
 ### Optional
 
 - `redfish_server` (Block List) List of server BMCs and their respective user credentials (see [below for nested schema](#nestedblock--redfish_server))
-- `resource_id` (String, Deprecated) Resource ID of the computer system. If not provided, the first system resource is used
 - `system_id` (String) System ID of the computer system. If not provided, the first system resource is used
 
 ### Read-Only

--- a/examples/data-sources/redfish_system_boot/data-source.tf
+++ b/examples/data-sources/redfish_system_boot/data-source.tf
@@ -25,9 +25,9 @@ data "redfish_system_boot" "system_boot" {
     ssl_insecure = each.value.ssl_insecure
   }
 
-  // resource_id is an optional argument. By default, the data source uses
+  // system_id is an optional argument. By default, the data source uses
   // the first ComputerSystem resource present in the ComputerSystem collection
-  resource_id = "System.Embedded.1"
+  system_id = "System.Embedded.1"
 }
 
 output "system_boot" {

--- a/redfish/models/system_boot.go
+++ b/redfish/models/system_boot.go
@@ -25,7 +25,6 @@ import (
 type SystemBootDataSource struct {
 	RedfishServer                []RedfishServer `tfsdk:"redfish_server"`
 	ID                           types.String    `tfsdk:"id"`
-	ResourceID                   types.String    `tfsdk:"resource_id"`
 	SystemID                     types.String    `tfsdk:"system_id"`
 	BootOrder                    types.List      `tfsdk:"boot_order"`
 	BootSourceOverrideEnabled    types.String    `tfsdk:"boot_source_override_enabled"`

--- a/redfish/provider/data_source_redfish_system_boot_test.go
+++ b/redfish/provider/data_source_redfish_system_boot_test.go
@@ -34,9 +34,6 @@ func TestAccRedfishSystemBoot_fetch(t *testing.T) {
 				Config: testAccRedfishDatasourceSystemBootConfig(creds, "System.Embedded.1"),
 			},
 			{
-				Config: testAccRedfishDatasourceSystemBootConfigWithSystemID(creds, "System.Embedded.1"),
-			},
-			{
 				Config: testAccRedfishDatasourceSystemBootConfigBasic(creds),
 			},
 		},
@@ -57,25 +54,6 @@ func TestAccRedfishSystemBoot_fetchInvalidID(t *testing.T) {
 }
 
 func testAccRedfishDatasourceSystemBootConfig(testingInfo TestingServerCredentials, id string) string {
-	return fmt.Sprintf(`
-	data "redfish_system_boot" "system_boot" {
-		resource_id = "%s"
-		redfish_server {
-		  user         = "%s"
-		  password     = "%s"
-		  endpoint     = "https://%s"
-		  ssl_insecure = true
-		}
-	  }	  
-	`,
-		id,
-		testingInfo.Username,
-		testingInfo.Password,
-		testingInfo.Endpoint,
-	)
-}
-
-func testAccRedfishDatasourceSystemBootConfigWithSystemID(testingInfo TestingServerCredentials, id string) string {
 	return fmt.Sprintf(`
 	data "redfish_system_boot" "system_boot" {
 		system_id = "%s"


### PR DESCRIPTION
<!--
Copyright (c) 2020-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
Removal of resource_id in System Boot datasource
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
redfish_system_boot DATASOURCE

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

#### Output from acceptance testing:
AT passed for redfish_system_boot:
![image](https://github.com/user-attachments/assets/1b49f76f-4e56-449e-aa5f-6f37b8243154)


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
