### PR TITLE
Adding support for 17G in User account resource

### DIFF
--- a/redfish/provider/resource_redfish_user_account.go
+++ b/redfish/provider/resource_redfish_user_account.go
@@ -467,7 +467,7 @@ func (r *UserAccountResource) Delete(ctx context.Context, req resource.DeleteReq
 	if !isGenerationSeventeenAndAbove {
 		// First set Role ID as "" and Enabled as false
 		payload := make(map[string]interface{})
-		payload["Enabled"] = "false"
+		payload["Enable"] = "false"
 		payload["RoleId"] = "None"
 		_, err = service.GetClient().Patch(account.ODataID, payload)
 		if err != nil {

--- a/redfish/provider/resource_redfish_user_account.go
+++ b/redfish/provider/resource_redfish_user_account.go
@@ -42,13 +42,13 @@ import (
 )
 
 const (
-	minUserNameLength = 1
-	maxUserNameLength = 16
-	minPasswordLength = 4
-	maxPasswordLength = 40
-	maxUserID         = 16
-	maxUserID17G      = 31
-	minUserID         = 2
+	minUserNameLength          = 1
+	maxUserNameLength          = 16
+	minPasswordLength          = 4
+	maxPasswordLength          = 40
+	maxUserID                  = 16
+	maxUserIDSeventeenAndAbove = 31
+	minUserID                  = 2
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -255,7 +255,7 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 		if len(accountList) < 31 {
 			if len(userID) > 0 {
 				userIdInt, err := strconv.Atoi(userID)
-				if !(userIdInt > minUserID && userIdInt <= maxUserID17G) {
+				if !(userIdInt > minUserID && userIdInt <= maxUserIDSeventeenAndAbove) {
 					resp.Diagnostics.AddError("User_id can vary between 3 to 31 only", "Update user ID")
 					return
 				}
@@ -265,25 +265,25 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 				}
 				payload["Id"] = userID
 			}
-			create_resp, err := service.GetClient().Post(url, payload)
+			createResp, err := service.GetClient().Post(url, payload)
 			if err != nil {
 				resp.Diagnostics.AddError(RedfishAPIErrorMsg, err.Error())
 				return
 			}
 			if len(userID) == 0 {
-				c_body, err := io.ReadAll(create_resp.Body)
+				createRespBody, err := io.ReadAll(createResp.Body)
 				if err != nil {
 					resp.Diagnostics.AddError("Failed to read response body", err.Error())
 					return
 				}
 				var decodedData map[string]interface{}
-				err = json.Unmarshal(c_body, &decodedData)
+				err = json.Unmarshal(createRespBody, &decodedData)
 				if err != nil {
 					resp.Diagnostics.AddError("Cannot convert response to string", err.Error())
 					return
 				}
-				usr_id, _ := decodedData["Id"].(string)
-				userID = usr_id
+				createdUsrId, _ := decodedData["Id"].(string)
+				userID = createdUsrId
 			}
 		} else {
 			// No room for new users

--- a/redfish/provider/resource_redfish_user_account.go
+++ b/redfish/provider/resource_redfish_user_account.go
@@ -144,6 +144,7 @@ func (*UserAccountResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 }
 
 // Create creates the resource and sets the initial Terraform state.
+// nolint: revive
 func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	tflog.Trace(ctx, "resource_user_account create : Started")
 
@@ -254,6 +255,7 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 		url, _ := filepath.Split(accountList[0].ODataID)
 		if len(accountList) < 31 {
 			if len(userID) > 0 {
+				// nolint: revive
 				userIdInt, err := strconv.Atoi(userID)
 				if !(userIdInt > minUserID && userIdInt <= maxUserIDSeventeenAndAbove) {
 					resp.Diagnostics.AddError("User_id can vary between 3 to 31 only", "Update user ID")

--- a/redfish/provider/resource_redfish_user_account.go
+++ b/redfish/provider/resource_redfish_user_account.go
@@ -271,7 +271,11 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 				return
 			}
 			if len(userID) == 0 {
-				c_body, _ := io.ReadAll(create_resp.Body)
+				c_body, err := io.ReadAll(create_resp.Body)
+				if err != nil {
+					resp.Diagnostics.AddError("Failed to read response body", err.Error())
+					return
+				}
 				var decodedData map[string]interface{}
 				err = json.Unmarshal(c_body, &decodedData)
 				if err != nil {

--- a/redfish/provider/resource_redfish_user_account.go
+++ b/redfish/provider/resource_redfish_user_account.go
@@ -216,12 +216,12 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 		// check if user id is valid or not
 		if len(userID) > 0 {
 			userIdInt, err := strconv.Atoi(userID)
-			if !(userIdInt > minUserID && userIdInt <= maxUserID) {
-				resp.Diagnostics.AddError("User_id can vary between 3 to 16 only", "Please update user ID")
-				return
-			}
 			if err != nil {
 				resp.Diagnostics.AddError("Invalid user ID", "Cannot convert user ID to int")
+				return
+			}
+			if !(userIdInt > minUserID && userIdInt <= maxUserID) {
+				resp.Diagnostics.AddError("user_id can vary between 3 to 16 only", "Please update user ID")
 				return
 			}
 		}
@@ -257,12 +257,12 @@ func (r *UserAccountResource) Create(ctx context.Context, req resource.CreateReq
 			if len(userID) > 0 {
 				// nolint: revive
 				userIdInt, err := strconv.Atoi(userID)
-				if !(userIdInt > minUserID && userIdInt <= maxUserIDSeventeenAndAbove) {
-					resp.Diagnostics.AddError("User_id can vary between 3 to 31 only", "Update user ID")
-					return
-				}
 				if err != nil {
 					resp.Diagnostics.AddError("Invalid user ID", "Cannot convert user ID to int")
+					return
+				}
+				if !(userIdInt > minUserID && userIdInt <= maxUserIDSeventeenAndAbove) {
+					resp.Diagnostics.AddError("user_id can vary between 3 to 31 only", "Update user ID")
 					return
 				}
 				payload["Id"] = userID

--- a/redfish/provider/resource_redfish_user_account_test.go
+++ b/redfish/provider/resource_redfish_user_account_test.go
@@ -20,9 +20,11 @@ package provider
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -63,6 +65,10 @@ func init() {
 
 // Test to create and update redfish user - Positive
 func TestAccRedfishUser_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -97,6 +103,10 @@ func TestAccRedfishUser_basic(t *testing.T) {
 
 // Test to create user with invalid role-id - Negative
 func TestAccRedfishUserInvalid_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -117,6 +127,10 @@ func TestAccRedfishUserInvalid_basic(t *testing.T) {
 
 // Test to create user with existing username - Negative
 func TestAccRedfishUserExisting_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -137,6 +151,10 @@ func TestAccRedfishUserExisting_basic(t *testing.T) {
 
 // Test to update username to existing username - Negative
 func TestAccRedfishUserUpdateInvalid_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -169,6 +187,10 @@ func TestAccRedfishUserUpdateInvalid_basic(t *testing.T) {
 
 // Test to create user with Invalid ID - Negative
 func TestAccRedfishUserUpdateInvalidId_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -189,6 +211,10 @@ func TestAccRedfishUserUpdateInvalidId_basic(t *testing.T) {
 
 // Test to update user-id - Negative
 func TestAccRedfishUserUpdateId_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -221,6 +247,10 @@ func TestAccRedfishUserUpdateId_basic(t *testing.T) {
 
 // Test to update username - positive
 func TestAccRedfishUserUpdateUser_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -255,6 +285,10 @@ func TestAccRedfishUserUpdateUser_basic(t *testing.T) {
 
 // Test to import user - positive
 func TestAccRedfishUserImportUser_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -278,6 +312,10 @@ func TestAccRedfishUserImportUser_basic(t *testing.T) {
 
 // Test to import user - negative
 func TestAccRedfishUserImportUser_invalid(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -297,6 +335,346 @@ func TestAccRedfishUserImportUser_invalid(t *testing.T) {
 			},
 		},
 	})
+}
+
+// Test to create and update redfish user - Positive
+func TestAccRedfishUser17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Operator",
+					true,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+			{ // Create user with ReadOnly role
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"ReadOnly",
+					false,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to create user with invalid role-id - Negative
+func TestAccRedfishUserInvalid17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Admin",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to create user with existing username - Negative
+func TestAccRedfishUserExisting17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"root",
+					"Xyz@123",
+					"Administrator",
+					true,
+					userID),
+				ExpectError: regexp.MustCompile("user root already exists against ID 2"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to update username to existing username - Negative
+func TestAccRedfishUserUpdateInvalid17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{ // Create User
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					true,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+			{ // Update User
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"root",
+					"Test@1234",
+					"Administrator",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile("user root already exists"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to create user with Invalid ID - Negative
+func TestAccRedfishUserUpdateInvalidId17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					true,
+					"1"),
+				ExpectError: regexp.MustCompile("User_id can vary between 3 to 31 only"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to update user-id - Negative
+func TestAccRedfishUserUpdateId17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{ // Create User
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					true,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+			{ // Update User
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					false,
+					"1"),
+				ExpectError: regexp.MustCompile("user_id cannot be updated"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to update username - positive
+func TestAccRedfishUserUpdateUser17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					true,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test2",
+					"Test@1234",
+					"Administrator",
+					false,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test2"),
+				),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to import user - positive
+func TestAccRedfishUserImportUser17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					true,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"None",
+					false,
+					userID),
+				ResourceName:  "redfish_user_account.user_config",
+				ImportState:   true,
+				ImportStateId: "{\"id\":\"15\",\"username\":\"" + creds.Username + "\",\"password\":\"" + creds.Password + "\",\"endpoint\":\"" + creds.Endpoint + "\",\"ssl_insecure\":true}",
+				ExpectError:   nil,
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// Test to import user - negative
+func TestAccRedfishUserImportUser17G_invalid(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"None",
+					false,
+					userID),
+				ResourceName:  "redfish_user_account.user_config",
+				ImportState:   true,
+				ImportStateId: "{\"id\":\"invalid\",\"username\":\"" + creds.Username + "\",\"password\":\"" + creds.Password + "\",\"endpoint\":\"" + creds.Endpoint + "\",\"ssl_insecure\":true}",
+				ExpectError:   regexp.MustCompile("Error when retrieving accounts"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // validation tests - Negative

--- a/redfish/provider/resource_redfish_user_account_test.go
+++ b/redfish/provider/resource_redfish_user_account_test.go
@@ -74,6 +74,9 @@ func TestAccRedfishUser_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -86,6 +89,12 @@ func TestAccRedfishUser_basic(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -99,6 +108,9 @@ func TestAccRedfishUser_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to create user with invalid role-id - Negative
@@ -112,6 +124,9 @@ func TestAccRedfishUserInvalid_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -123,6 +138,9 @@ func TestAccRedfishUserInvalid_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to create user with existing username - Negative
@@ -136,6 +154,9 @@ func TestAccRedfishUserExisting_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"root",
@@ -147,6 +168,9 @@ func TestAccRedfishUserExisting_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to update username to existing username - Negative
@@ -160,6 +184,9 @@ func TestAccRedfishUserUpdateInvalid_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -172,6 +199,12 @@ func TestAccRedfishUserUpdateInvalid_basic(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"root",
@@ -183,6 +216,9 @@ func TestAccRedfishUserUpdateInvalid_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to create user with Invalid ID - Negative
@@ -196,6 +232,9 @@ func TestAccRedfishUserUpdateInvalidId_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -207,6 +246,9 @@ func TestAccRedfishUserUpdateInvalidId_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to update user-id - Negative
@@ -220,6 +262,9 @@ func TestAccRedfishUserUpdateId_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -232,6 +277,12 @@ func TestAccRedfishUserUpdateId_basic(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -243,6 +294,9 @@ func TestAccRedfishUserUpdateId_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to update username - positive
@@ -256,6 +310,9 @@ func TestAccRedfishUserUpdateUser_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -268,6 +325,12 @@ func TestAccRedfishUserUpdateUser_basic(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test2",
@@ -281,6 +344,9 @@ func TestAccRedfishUserUpdateUser_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to import user - positive
@@ -294,6 +360,9 @@ func TestAccRedfishUserImportUser_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -308,6 +377,9 @@ func TestAccRedfishUserImportUser_basic(t *testing.T) {
 			},
 		},
 	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
 }
 
 // Test to import user - negative
@@ -321,6 +393,9 @@ func TestAccRedfishUserImportUser_invalid(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(false, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -332,6 +407,85 @@ func TestAccRedfishUserImportUser_invalid(t *testing.T) {
 				ImportState:   true,
 				ImportStateId: "{\"id\":\"invalid\",\"username\":\"" + creds.Username + "\",\"password\":\"" + creds.Password + "\",\"endpoint\":\"" + creds.Endpoint + "\",\"ssl_insecure\":true}",
 				ExpectError:   regexp.MustCompile("Error when retrieving accounts"),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+// validation tests - Negative
+func TestAccRedfishUserValidation_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1234567890123456",
+					"Test@1234",
+					"Administrator",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile("Invalid Attribute Value Length"),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"T@1",
+					"Administrator",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile("Attribute password string length must be between 4 and 40"),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"test123",
+					"Administrator",
+					true,
+					userID),
+				ExpectError: regexp.MustCompile("Password validation failed"),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"Test@1234",
+					"Administrator",
+					false,
+					"2"),
+				ExpectError: regexp.MustCompile("User ID already exists"),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test2",
+					"Test@1234",
+					"Administrator",
+					false,
+					userID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test2"),
+				),
+			},
+			{
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"test1",
+					"test123",
+					"Administrator",
+					true,
+					userID),
+				ExpectError: regexp.MustCompile("Password validation failed"),
 			},
 		},
 	})
@@ -362,7 +516,7 @@ func TestAccRedfishUser17G_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
 				),
 			},
-			{ // Create user with ReadOnly role
+			{ // Update user with ReadOnly role
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"test1",
@@ -372,6 +526,36 @@ func TestAccRedfishUser17G_basic(t *testing.T) {
 					userID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+				),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
+func TestAccRedfishUser17GWithoutId_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{ // Create user with ReadOnly role without user id
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
+				Config: testAccRedfishResourceUserConfigWithoutId(
+					creds,
+					"test2",
+					"Test@123",
+					"Operator",
+					false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test2"),
 				),
 			},
 		},
@@ -451,22 +635,7 @@ func TestAccRedfishUserUpdateInvalid17G_basic(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			{ // Create User
-				PreConfig: func() {
-					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
-				},
-				Config: testAccRedfishResourceUserConfig(
-					creds,
-					"test1",
-					"Test@1234",
-					"Administrator",
-					true,
-					userID),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
-				),
-			},
-			{ // Update User
+			{
 				Config: testAccRedfishResourceUserConfig(
 					creds,
 					"root",
@@ -499,7 +668,7 @@ func TestAccRedfishUserUpdateInvalidId17G_basic(t *testing.T) {
 				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
-					"test1",
+					"newtest1",
 					"Test@1234",
 					"Administrator",
 					true,
@@ -531,8 +700,8 @@ func TestAccRedfishUserUpdateId17G_basic(t *testing.T) {
 					creds,
 					"test1",
 					"Test@1234",
-					"Administrator",
-					true,
+					"ReadOnly",
+					false,
 					userID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
@@ -543,7 +712,7 @@ func TestAccRedfishUserUpdateId17G_basic(t *testing.T) {
 					creds,
 					"test1",
 					"Test@1234",
-					"Administrator",
+					"ReadOnly",
 					false,
 					"1"),
 				ExpectError: regexp.MustCompile("user_id cannot be updated"),
@@ -573,8 +742,8 @@ func TestAccRedfishUserUpdateUser17G_basic(t *testing.T) {
 					creds,
 					"test1",
 					"Test@1234",
-					"Administrator",
-					true,
+					"ReadOnly",
+					false,
 					userID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
@@ -585,7 +754,7 @@ func TestAccRedfishUserUpdateUser17G_basic(t *testing.T) {
 					creds,
 					"test2",
 					"Test@1234",
-					"Administrator",
+					"ReadOnly",
 					false,
 					userID),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -615,19 +784,25 @@ func TestAccRedfishUserImportUser17G_basic(t *testing.T) {
 				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
-					"test1",
+					"test2",
 					"Test@1234",
-					"Administrator",
-					true,
+					"ReadOnly",
+					false,
 					userID),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test1"),
+					resource.TestCheckResourceAttr("redfish_user_account.user_config", "username", "test2"),
 				),
 			},
 			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(true, nil).Build()
+				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
-					"test1",
+					"test2",
 					"Test@1234",
 					"None",
 					false,
@@ -660,9 +835,9 @@ func TestAccRedfishUserImportUser17G_invalid(t *testing.T) {
 				},
 				Config: testAccRedfishResourceUserConfig(
 					creds,
-					"test1",
+					"test2",
 					"Test@1234",
-					"None",
+					"ReadOnly",
 					false,
 					userID),
 				ResourceName:  "redfish_user_account.user_config",
@@ -678,7 +853,11 @@ func TestAccRedfishUserImportUser17G_invalid(t *testing.T) {
 }
 
 // validation tests - Negative
-func TestAccRedfishUserValidation_basic(t *testing.T) {
+func TestAccRedfishUserValidation17G_basic(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version != "17" {
+		t.Skip("Skipping Bios Tests for below 17G")
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -728,7 +907,7 @@ func TestAccRedfishUserValidation_basic(t *testing.T) {
 					creds,
 					"test2",
 					"Test@1234",
-					"Administrator",
+					"ReadOnly",
 					false,
 					userID),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -750,6 +929,10 @@ func TestAccRedfishUserValidation_basic(t *testing.T) {
 }
 
 func TestAccRedfishUserPassword_alias(t *testing.T) {
+	version := os.Getenv("TF_TESTING_REDFISH_VERSION")
+	if version == "17" {
+		t.Skip("Skipping Bios Tests for 17G")
+	}
 	serverAlias := "my-server-1"
 	testUser, testUserPass, testUserRole := "testAlias", "Test@1234", "Administrator"
 	resource.Test(t, resource.TestCase{
@@ -767,6 +950,64 @@ func TestAccRedfishUserPassword_alias(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRedfishUserCreateCfgError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					FunctionMocker = mockey.Mock(NewConfig).Return(nil, fmt.Errorf("mock error")).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"testerr",
+					"TestPass@1234",
+					"Operator",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile(`.*mock error*.`),
+			},
+			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(isServerGenerationSeventeenAndAbove).Return(nil, fmt.Errorf("Error retrieving the server generation")).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"testerr",
+					"TestPass@1234",
+					"Operator",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile(`.*Error retrieving the server generation*.`),
+			},
+			{
+				PreConfig: func() {
+					if FunctionMocker != nil {
+						FunctionMocker.Release()
+					}
+					FunctionMocker = mockey.Mock(GetAccountList).Return(nil, fmt.Errorf("Error when retrieving account list")).Build()
+				},
+				Config: testAccRedfishResourceUserConfig(
+					creds,
+					"testerr",
+					"TestPass@1234",
+					"Operator",
+					false,
+					userID),
+				ExpectError: regexp.MustCompile(`.*Error when retrieving account list*.`),
+			},
+		},
+	})
+	if FunctionMocker != nil {
+		FunctionMocker.Release()
+	}
+}
+
 func testAccRedfishResourceUserConfig(testingInfo TestingServerCredentials,
 	username string,
 	password string,
@@ -800,6 +1041,39 @@ func testAccRedfishResourceUserConfig(testingInfo TestingServerCredentials,
 		roleId,
 		enabled,
 		userId,
+	)
+}
+
+func testAccRedfishResourceUserConfigWithoutId(testingInfo TestingServerCredentials,
+	username string,
+	password string,
+	roleId string,
+	enabled bool,
+) string {
+	return fmt.Sprintf(`
+
+		resource "redfish_user_account" "user_config" {
+
+		  redfish_server {
+			user = "%s"
+			password = "%s"
+			endpoint = "%s"
+			ssl_insecure = true
+		  }
+
+		  username = "%s"
+		  password = "%s"
+		  role_id = "%s"
+		  enabled = %t
+		}
+		`,
+		testingInfo.Username,
+		testingInfo.Password,
+		testingInfo.Endpoint,
+		username,
+		password,
+		roleId,
+		enabled,
 	)
 }
 

--- a/redfish/provider/resource_redfish_user_account_test.go
+++ b/redfish/provider/resource_redfish_user_account_test.go
@@ -242,7 +242,7 @@ func TestAccRedfishUserUpdateInvalidId_basic(t *testing.T) {
 					"Administrator",
 					true,
 					"1"),
-				ExpectError: regexp.MustCompile("User_id can vary between 3 to 16 only"),
+				ExpectError: regexp.MustCompile("user_id can vary between 3 to 16 only"),
 			},
 		},
 	})
@@ -673,7 +673,7 @@ func TestAccRedfishUserUpdateInvalidId17G_basic(t *testing.T) {
 					"Administrator",
 					true,
 					"1"),
-				ExpectError: regexp.MustCompile("User_id can vary between 3 to 31 only"),
+				ExpectError: regexp.MustCompile("user_id can vary between 3 to 31 only"),
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Copyright (c) 2020-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding support for 17G in User account resource


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

#### Output from acceptance testing:
16G AT:
![UA_16AT](https://github.com/user-attachments/assets/87ff0726-718b-49b1-aa6d-1527a50ade47)

17G AT:
![UA_17AT](https://github.com/user-attachments/assets/6f16db31-ffdf-457d-ae29-4c5faf889c8b)


#### Output from unit testing:
16G UT:
![UA_16_UT](https://github.com/user-attachments/assets/c2a3df0f-7d01-4377-9296-032deb3fe3eb)

17G UT:
![UA_17_UT](https://github.com/user-attachments/assets/1f8cddf4-f43e-4d6e-bb88-c09aea57fbdd)

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
