### PR TITLE
Adding Support for 17G in user account password resource

### DIFF
--- a/redfish/provider/resource_redfish_user_account_password.go
+++ b/redfish/provider/resource_redfish_user_account_password.go
@@ -195,18 +195,18 @@ func (r *UserAccountPasswordResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	tflog.Trace(ctx, "resource_user_account_Password create: updating state finished, saving ...")
+	tflog.Trace(ctx, "resource_user_account_password create: updating state finished, saving ...")
 	state = plan
 	state.ID = types.StringValue(userAccount.ODataID)
 	// Save into State
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	tflog.Trace(ctx, "resource_user_account_Password create: finish")
+	tflog.Trace(ctx, "resource_user_account_password create: finish")
 }
 
 // Read refreshes the Terraform state with the latest data.
 func (*UserAccountPasswordResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	tflog.Trace(ctx, "resource_user_accountPassword read: started")
+	tflog.Trace(ctx, "resource_user_account_password read: started")
 	// Get Plan Data
 	var state models.UserAccountPassword
 	diags := req.State.Get(ctx, &state)
@@ -215,7 +215,7 @@ func (*UserAccountPasswordResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	tflog.Trace(ctx, "resource_user_account_Password Read: finish")
+	tflog.Trace(ctx, "resource_user_account_password Read: finish")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.


### PR DESCRIPTION
<!--
Copyright (c) 2020-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adding Support for 17G in user account password resource

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

#### Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

#### Output from acceptance testing:
17G AT:
![image](https://github.com/user-attachments/assets/0b13f89b-1752-4ae3-8e2c-1f38e2a59aa4)

17G UT:
![image](https://github.com/user-attachments/assets/928d1d61-e643-41c2-a251-7228523b0c06)



16G AT:
![image](https://github.com/user-attachments/assets/99a73c45-ef7b-4699-8f63-14bbec87d058)



16G UT:
![image](https://github.com/user-attachments/assets/35dece54-09bb-4cfd-9610-ba304e8f15c4)


<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<!--- Please keep this note for the community --->
#### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
