### PR TITLE
Prevent virtual media resources from running in parallel

### DIFF
--- a/redfish/provider/resource_redfish_virtual_media.go
+++ b/redfish/provider/resource_redfish_virtual_media.go
@@ -173,6 +173,10 @@ func (r *virtualMediaResource) Create(ctx context.Context, req resource.CreateRe
 		TransferProtocolType: redfish.TransferProtocolType(plan.TransferProtocolType.ValueString()),
 		WriteProtected:       plan.WriteProtected.ValueBool(),
 	}
+
+	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
+	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
+
 	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
 		resp.Diagnostics.AddError(ServiceErrorMsg, err.Error())
@@ -378,6 +382,9 @@ func (r *virtualMediaResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
+	redfishMutexKV.Lock(plan.RedfishServer[0].Endpoint.ValueString())
+	defer redfishMutexKV.Unlock(plan.RedfishServer[0].Endpoint.ValueString())
+
 	// Get service
 	api, err := NewConfig(r.p, &plan.RedfishServer)
 	if err != nil {
@@ -458,6 +465,9 @@ func (r *virtualMediaResource) Delete(ctx context.Context, req resource.DeleteRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	redfishMutexKV.Lock(state.RedfishServer[0].Endpoint.ValueString())
+	defer redfishMutexKV.Unlock(state.RedfishServer[0].Endpoint.ValueString())
 
 	// Get service
 	api, err := NewConfig(r.p, &state.RedfishServer)


### PR DESCRIPTION
Fixes https://github.com/dell/terraform-provider-redfish/issues/327
Adding a lock will stop all Virtual media resources from running in parallel, and solve the race condition.

<img width="754" height="179" alt="image" src="https://github.com/user-attachments/assets/94b35179-928a-41cd-baf0-cac5a7bb3ec8" />
