### PR TITLE
[ECS02C-1162] Fix PCISlot JSON unmarshal error when iDRAC returns numeric value

### DIFF
--- a/gofish/dell/storage.go
+++ b/gofish/dell/storage.go
@@ -19,6 +19,7 @@ package dell
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stmcginnis/gofish/redfish"
 )
@@ -51,7 +52,7 @@ type Controller struct {
 	MaxAvailablePCILinkSpeed         string `json:"MaxAvailablePCILinkSpeed"`
 	MaxPossiblePCILinkSpeed          string `json:"MaxPossiblePCILinkSpeed"`
 	Name                             string `json:"Name"`
-	PCISlot                          string `json:"PCISlot"`
+	PCISlot                          any    `json:"PCISlot"`
 	PatrolReadState                  string `json:"PatrolReadState"`
 	PersistentHotspare               string `json:"PersistentHotspare"`
 	RealtimeCapability               string `json:"RealtimeCapability"`
@@ -65,6 +66,15 @@ type Controller struct {
 	SupportRAID10UnevenSpans         string `json:"SupportRAID10UnevenSpans"`
 	SupportsLKMtoSEKMTransition      string `json:"SupportsLKMtoSEKMTransition"`
 	T10PICapability                  string `json:"T10PICapability"`
+}
+
+// PCISlotString returns PCISlot as a string regardless of whether the
+// iDRAC firmware returned it as a JSON string or number.
+func (c Controller) PCISlotString() string {
+	if c.PCISlot == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", c.PCISlot)
 }
 
 // ControllerBattery to get controller battery data

--- a/gofish/dell/storageController.go
+++ b/gofish/dell/storageController.go
@@ -19,6 +19,7 @@ package dell
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stmcginnis/gofish/common"
 	"github.com/stmcginnis/gofish/redfish"
@@ -77,7 +78,7 @@ type DellStorageController struct {
 	MaxPossiblePCILinkSpeed                    string
 	MaxSpansInVolumeCount                      int64
 	MaxSupportedVolumesCount                   int64
-	PCISlot                                    string
+	PCISlot                                    any
 	PatrolReadIterationsCount                  int64
 	PatrolReadMode                             string
 	PatrolReadRatePercent                      int64
@@ -100,6 +101,15 @@ type DellStorageController struct {
 	SupportedInitializationTypes               []string
 	SupportsLKMtoSEKMTransition                string
 	T10PICapability                            string
+}
+
+// PCISlotString returns PCISlot as a string regardless of whether the
+// iDRAC firmware returned it as a JSON string or number.
+func (d DellStorageController) PCISlotString() string {
+	if d.PCISlot == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", d.PCISlot)
 }
 
 // StorageController given redfish.StorageController, returns dell.StorageControllerExtended.

--- a/gofish/dell/storage_test.go
+++ b/gofish/dell/storage_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2021-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://mozilla.org/MPL/2.0/
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dell
+
+import (
+	"testing"
+)
+
+func TestControllerPCISlotString(t *testing.T) {
+	tests := []struct {
+		name     string
+		pcislot  any
+		expected string
+	}{
+		{
+			name:     "string value",
+			pcislot:  "1",
+			expected: "1",
+		},
+		{
+			name:     "numeric value",
+			pcislot:  1,
+			expected: "1",
+		},
+		{
+			name:     "float value",
+			pcislot:  1.0,
+			expected: "1",
+		},
+		{
+			name:     "nil value",
+			pcislot:  nil,
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			pcislot:  "",
+			expected: "",
+		},
+		{
+			name:     "numeric zero",
+			pcislot:  0,
+			expected: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Controller{PCISlot: tt.pcislot}
+			result := c.PCISlotString()
+			if result != tt.expected {
+				t.Errorf("PCISlotString() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDellStorageControllerPCISlotString(t *testing.T) {
+	tests := []struct {
+		name     string
+		pcislot  any
+		expected string
+	}{
+		{
+			name:     "string value",
+			pcislot:  "2",
+			expected: "2",
+		},
+		{
+			name:     "numeric value",
+			pcislot:  2,
+			expected: "2",
+		},
+		{
+			name:     "float value",
+			pcislot:  2.0,
+			expected: "2",
+		},
+		{
+			name:     "nil value",
+			pcislot:  nil,
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			pcislot:  "",
+			expected: "",
+		},
+		{
+			name:     "numeric zero",
+			pcislot:  0,
+			expected: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := DellStorageController{PCISlot: tt.pcislot}
+			result := d.PCISlotString()
+			if result != tt.expected {
+				t.Errorf("PCISlotString() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/redfish/provider/data_source_redfish_storage.go
+++ b/redfish/provider/data_source_redfish_storage.go
@@ -298,6 +298,7 @@ func newDellController(input dell.Controller) models.DellController {
 		MaxAvailablePCILinkSpeed:         types.StringValue(input.MaxAvailablePCILinkSpeed),
 		MaxPossiblePCILinkSpeed:          types.StringValue(input.MaxPossiblePCILinkSpeed),
 		Name:                             types.StringValue(input.Name),
+		PCISlot:                          types.StringValue(input.PCISlotString()),
 		PatrolReadState:                  types.StringValue(input.PatrolReadState),
 		PersistentHotspare:               types.StringValue(input.PersistentHotspare),
 		RealtimeCapability:               types.StringValue(input.RealtimeCapability),

--- a/redfish/provider/data_source_redfish_storage_controller.go
+++ b/redfish/provider/data_source_redfish_storage_controller.go
@@ -376,7 +376,7 @@ func newDellStorageController(input dell.DellStorageController) models.DellStora
 		MaxPossiblePCILinkSpeed:          types.StringValue(input.MaxPossiblePCILinkSpeed),
 		MaxSpansInVolumeCount:            types.Int64Value(input.MaxSpansInVolumeCount),
 		MaxSupportedVolumesCount:         types.Int64Value(input.MaxSupportedVolumesCount),
-		PCISlot:                          types.StringValue(input.PCISlot),
+		PCISlot:                          types.StringValue(input.PCISlotString()),
 		PatrolReadIterationsCount:        types.Int64Value(input.PatrolReadIterationsCount),
 		PatrolReadMode:                   types.StringValue(input.PatrolReadMode),
 		PatrolReadRatePercent:            types.Int64Value(input.PatrolReadRatePercent),


### PR DESCRIPTION
## Issue

Fixes #336 (Jira: ECS02C-1162)

Some iDRAC firmware versions return the `PCISlot` field as a JSON number (e.g. `1`) instead of a string (e.g. `"1"`). The Go structs in the gofish SDK defined `PCISlot` as `string`, causing JSON unmarshaling to fail with:

```
json: cannot unmarshal number into Go struct field Controller.Dell.temp.DellController.PCISlot of type string
```

This caused the `redfish_storage` and `redfish_storage_controller` datasources to fail when querying certain Dell servers.

## Changes

- Changed `PCISlot` field type from `string` to `interface{}` in:
  - `gofish/dell/storage.go` (Controller struct)
  - `gofish/dell/storageController.go` (DellStorageController struct)
- Added `PCISlotString()` helper methods on both structs to safely convert to string regardless of JSON type
- Updated mapping code to use `PCISlotString()`:
  - `redfish/provider/data_source_redfish_storage.go` (also added missing PCISlot mapping)
  - `redfish/provider/data_source_redfish_storage_controller.go`

## Testing

- Tested against iDRAC with NonRAID.Slot.1-1 controller with numeric PCISlot — previously failed, now succeeds with `pci_slot = "1"`
- Regression tested against iDRAC with null PCISlot — still works correctly, no regression

## No Breaking Changes

The downstream Terraform model (`types.String`) remains unchanged. Users will see the same string output regardless of whether the iDRAC returns a JSON string or number.